### PR TITLE
Add `watch` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "scripts": {
     "start": "slate-tools start",
+    "watch": "slate-tools start --skipFirstDeploy",
     "build": "slate-tools build",
     "deploy": "slate-tools build && slate-tools deploy",
     "zip": "slate-tools build && slate-tools zip",


### PR DESCRIPTION
We have found that having a `npm run watch` script has been incredibly useful to avoid waiting a couple minutes to fire up development every day.