### PR TITLE
fix: repetitive title

### DIFF
--- a/src/layout/theme.liquid
+++ b/src/layout/theme.liquid
@@ -8,27 +8,28 @@
   <meta name="theme-color" content="{{ settings.color_primary }}">
   <link rel="canonical" href="{{ canonical_url }}">
 
-  {% if settings.favicon != blank %}
+  {%- if settings.favicon != blank -%}
     <link rel="shortcut icon" href="{{ settings.favicon | img_url: '32x32' }}" type="image/png">
-  {% endif %}
+  {%- endif -%}
 
-  {% capture seo_title %}
+  {%- capture seo_title -%}
     {{ page_title }}
-    {% if current_tags %}
-      {%- assign meta_tags = current_tags | join: ', ' %} &ndash; {{ 'general.meta.tags' | t: tags: meta_tags -}}
-    {% endif %}
-    {% if current_page != 1 %}
+    {%- if current_tags -%}
+      {%- assign meta_tags = current_tags | join: ', ' -%} &ndash; {{ 'general.meta.tags' | t: tags: meta_tags -}}
+    {%- endif -%}
+    {%- if current_page != 1 -%}
       &ndash; {{ 'general.meta.page' | t: page: current_page }}
-    {% endif %}
-    {% unless page_title contains shop.name %}
+    {%- endif -%}
+    {%- assign escaped_page_title = page_title | escape -%}
+    {%- unless escaped_page_title contains shop.name -%}
       &ndash; {{ shop.name }}
-    {% endunless %}
-  {% endcapture %}
-  <title>{{ seo_title }}</title>
+    {%- endunless -%}
+  {%- endcapture -%}
+  <title>{{ seo_title | strip }}</title>
 
-  {% if page_description %}
+  {%- if page_description -%}
     <meta name="description" content="{{ page_description | escape }}">
-  {% endif %}
+  {%- endif -%}
 
   {% include 'social-meta-tags' %}
 


### PR DESCRIPTION
### What this PR Does
Related to a fix done in this PR [#269](https://github.com/Shopify/debut/pull/269) and this issue [#194](https://github.com/Shopify/debut/issues/194)
* This PR fixes the repetitive title on homepage 
  * when the homepage title is not specified by the merchant and store name includes an ` ' ` or ` " `
* This PR removes extra whitespace by adding whitespace control `{%- -%}`

[Starter Theme Demo](https://all-the-snow-things.myshopify.com/?preview_theme_id=32170508330)
Currently the homepage title is not defined
