### PR TITLE
Add newsletter section template

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -51,7 +51,7 @@
       "submit": "Suchen"
     },
     "newsletter_form": {
-      "newsletter_email": "Join our mailing list",
+      "newsletter_email": "Im Bilde sein",
       "email_placeholder": " E-Mail-Adresse ",
       "confirmation": " Danke für Ihre Anmeldung ",
       "submit": "Abonnieren"

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -49,6 +49,12 @@
       "title": "Suchen Sie auf unserer Seite nach Produkten",
       "placeholder": "Durchsuchen Sie unseren Shop",
       "submit": "Suchen"
+    },
+    "newsletter_form": {
+      "newsletter_email": "Join our mailing list",
+      "email_placeholder": " E-Mail-Adresse ",
+      "confirmation": " Danke für Ihre Anmeldung ",
+      "submit": "Abonnieren"
     }
   },
   "blogs": {

--- a/src/locales/en.default.json
+++ b/src/locales/en.default.json
@@ -47,6 +47,12 @@
       "title": "Search for products on our site",
       "placeholder": "Search our store",
       "submit": "Search"
+    },
+    "newsletter_form": {
+      "newsletter_email": "Join our mailing list",
+      "email_placeholder": "Email address",
+      "confirmation": "Thanks for subscribing",
+      "submit": "Subscribe"
     }
   },
   "blogs": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -48,6 +48,12 @@
       "title": "Buscar productos en nuestro sitio",
       "placeholder": "buscar en nuestra tienda",
       "submit": "Buscar"
+    },
+    "newsletter_form": {
+      "newsletter_email": "Join our mailing list",
+      "email_placeholder": "Dirección de correo electrónico",
+      "confirmation": "Gracias por su suscripción",
+      "submit": "Suscribir"
     }
   },
   "blogs": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -50,7 +50,7 @@
       "submit": "Buscar"
     },
     "newsletter_form": {
-      "newsletter_email": "Join our mailing list",
+      "newsletter_email": "Estar en el saber",
       "email_placeholder": "Dirección de correo electrónico",
       "confirmation": "Gracias por su suscripción",
       "submit": "Suscribir"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -51,7 +51,7 @@
       "submit": "Recherche"
     },
     "newsletter_form": {
-      "newsletter_email": "Join our mailing list",
+      "newsletter_email": "Soyez au courant",
       "email_placeholder": "Adresse courriel",
       "confirmation": "Merci pour votre abonnement",
       "submit": "S'inscrire"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -49,6 +49,12 @@
       "title": "Effectuez une recherche",
       "placeholder": "Rechercher dans la boutique",
       "submit": "Recherche"
+    },
+    "newsletter_form": {
+      "newsletter_email": "Join our mailing list",
+      "email_placeholder": "Adresse courriel",
+      "confirmation": "Merci pour votre abonnement",
+      "submit": "S'inscrire"
     }
   },
   "blogs": {

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -49,6 +49,12 @@
       "title": "Procure produtos no nosso site",
       "placeholder": "Procure na nossa loja",
       "submit": "Procurar"
+    },
+    "newsletter_form": {
+      "newsletter_email": "Assine nossa newsletter",
+      "email_placeholder": "E-mail",
+      "confirmation": "Obrigado por se inscrever",
+      "submit": "Me inscrever"
     }
   },
   "blogs": {

--- a/src/locales/pt-PT.json
+++ b/src/locales/pt-PT.json
@@ -51,7 +51,7 @@
       "submit": "Procurar"
     },
     "newsletter_form": {
-      "newsletter_email": "Join our mailing list",
+      "newsletter_email": "Esteja por dentro",
       "email_placeholder": "Endereço de correio eletrónico",
       "confirmation": "Obrigado por subscrever",
       "submit": "Subscrever"

--- a/src/locales/pt-PT.json
+++ b/src/locales/pt-PT.json
@@ -49,6 +49,12 @@
       "title": "Procure produtos no nosso site",
       "placeholder": "Procure na nossa loja",
       "submit": "Procurar"
+    },
+    "newsletter_form": {
+      "newsletter_email": "Join our mailing list",
+      "email_placeholder": "Endereço de correio eletrónico",
+      "confirmation": "Obrigado por subscrever",
+      "submit": "Subscrever"
     }
   },
   "blogs": {

--- a/src/sections/newsletter.liquid
+++ b/src/sections/newsletter.liquid
@@ -1,0 +1,70 @@
+<div class="newsletter-section{% if section.settings.show_background %} index-section--newsletter-background{% endif %}">
+  <div class="page-width text-center">
+    <div class="section-header text-center">
+      {% if section.settings.section_title != blank %}
+        <label for="Email" class="h2">{{ section.settings.section_title | escape }}</label>
+      {% endif %}
+      {% if section.settings.subheading != blank %}
+        <p>{{ section.settings.subheading | escape }}</p>
+      {% endif %}
+    </div>
+    {% form 'customer' %}
+      {{ form.errors | default_errors }}
+      {% if form.posted_successfully? %}
+        <p class="form--success">{{ 'general.newsletter_form.confirmation' | t }}</p>
+      {% else %}
+        <div class="input-group password__input-group">
+          <input type="hidden" name="contact[tags]" value="newsletter">
+          <input type="email"
+            name="contact[email]"
+            id="Email"
+            class="input-group__field newsletter__input"
+            value="{% if customer %}{{ customer.email }}{% endif %}"
+            placeholder="{{ 'general.newsletter_form.email_placeholder' | t }}"
+            autocorrect="off"
+            autocapitalize="off">
+          <span class="input-group__btn">
+            <button type="submit" class="btn newsletter__submit" name="commit" id="Subscribe">
+              <span class="newsletter__submit-text--large">{{ 'general.newsletter_form.submit' | t }}</span>
+            </button>
+          </span>
+        </div>
+      {% endif %}
+    {% endform %}
+  </div>
+</div>
+
+{% schema %}
+  {
+    "name": "Newsletter",
+    "class": "index-section index-section--flush",
+    "settings": [
+      {
+        "type": "text",
+        "id": "section_title",
+        "label": "Heading",
+        "default": "Subscribe to our newsletter"
+      },
+      {
+        "type": "text",
+        "id": "subheading",
+        "label": "Subheading",
+        "default": "A short sentence describing what someone will receive by subscribing"
+      },
+      {
+        "id": "show_background",
+        "type": "checkbox",
+        "label": "Show background",
+        "default": true
+      },
+      {
+        "type": "paragraph",
+        "content": "Any customers who sign up will have an account created for them in Shopify. [View customers](/admin/customers?query=&accepts_marketing=1)"
+      }
+    ],
+    "presets": [{
+      "name": "Newsletter",
+      "category": "Promotional"
+    }]
+  }
+{% endschema %}

--- a/src/sections/newsletter.liquid
+++ b/src/sections/newsletter.liquid
@@ -6,36 +6,33 @@
   - Heading: title of the newsletter section
   - Subheading: description of the newsletter section
 {%- endcomment -%}
-<div>
-  <div>
-    {% if section.settings.section_title != blank %}
-      <label for="Email">{{ section.settings.section_title | escape }}</label>
-    {% endif %}
-    {% if section.settings.subheading != blank %}
-      <p>{{ section.settings.subheading | escape }}</p>
-    {% endif %}
-  </div>
+<section>
+  {% if section.settings.section_title != blank %}
+    <label for="Email">{{ section.settings.section_title | escape }}</label>
+  {% endif %}
+  {% if section.settings.subheading != blank %}
+    <p>{{ section.settings.subheading | escape }}</p>
+  {% endif %}
+
   {% form 'customer' %}
     {{ form.errors | default_errors }}
     {% if form.posted_successfully? %}
       <p>{{ 'general.newsletter_form.confirmation' | t }}</p>
     {% else %}
-      <div>
-        <input type="hidden" name="contact[tags]" value="newsletter">
-        <input type="email"
-          name="contact[email]"
-          id="Email"
-          value="{% if customer %}{{ customer.email }}{% endif %}"
-          placeholder="{{ 'general.newsletter_form.email_placeholder' | t }}"
-          autocorrect="off"
-          autocapitalize="off">
-        <button type="submit" name="commit" id="Subscribe">
-          <span>{{ 'general.newsletter_form.submit' | t }}</span>
-        </button>
-      </div>
+      <input type="hidden" name="contact[tags]" value="newsletter">
+      <input type="email"
+        name="contact[email]"
+        id="Email"
+        value="{% if customer.email != blank %}{{ customer.email }}{% endif %}"
+        placeholder="{{ 'general.newsletter_form.email_placeholder' | t }}"
+        autocorrect="off"
+        autocapitalize="off">
+      <button type="submit" name="commit" id="Subscribe">
+        <span>{{ 'general.newsletter_form.submit' | t }}</span>
+      </button>
     {% endif %}
   {% endform %}
-</div>
+</section>
 
 {% schema %}
   {

--- a/src/sections/newsletter.liquid
+++ b/src/sections/newsletter.liquid
@@ -2,7 +2,7 @@
   This is a required section for the Shopify Theme Store.
   It is available when you add "Newsletter" section on the Theme Editor.
 
-  Theme Store optional settings
+  Theme Store required settings
   - Heading: title of the newsletter section
   - Subheading: description of the newsletter section
 {%- endcomment -%}
@@ -37,7 +37,6 @@
 {% schema %}
   {
     "name": "Newsletter",
-    "class": "index-section index-section--flush",
     "settings": [
       {
         "type": "text",

--- a/src/sections/newsletter.liquid
+++ b/src/sections/newsletter.liquid
@@ -1,37 +1,40 @@
-<div class="newsletter-section{% if section.settings.show_background %} index-section--newsletter-background{% endif %}">
-  <div class="page-width text-center">
-    <div class="section-header text-center">
-      {% if section.settings.section_title != blank %}
-        <label for="Email" class="h2">{{ section.settings.section_title | escape }}</label>
-      {% endif %}
-      {% if section.settings.subheading != blank %}
-        <p>{{ section.settings.subheading | escape }}</p>
-      {% endif %}
-    </div>
-    {% form 'customer' %}
-      {{ form.errors | default_errors }}
-      {% if form.posted_successfully? %}
-        <p class="form--success">{{ 'general.newsletter_form.confirmation' | t }}</p>
-      {% else %}
-        <div class="input-group password__input-group">
-          <input type="hidden" name="contact[tags]" value="newsletter">
-          <input type="email"
-            name="contact[email]"
-            id="Email"
-            class="input-group__field newsletter__input"
-            value="{% if customer %}{{ customer.email }}{% endif %}"
-            placeholder="{{ 'general.newsletter_form.email_placeholder' | t }}"
-            autocorrect="off"
-            autocapitalize="off">
-          <span class="input-group__btn">
-            <button type="submit" class="btn newsletter__submit" name="commit" id="Subscribe">
-              <span class="newsletter__submit-text--large">{{ 'general.newsletter_form.submit' | t }}</span>
-            </button>
-          </span>
-        </div>
-      {% endif %}
-    {% endform %}
+{%- comment -%}
+  This is a required section for the Shopify Theme Store.
+  It is available when you add "Newsletter" section on the Theme Editor.
+
+  Theme Store optional settings
+  - Heading: title of the newsletter section
+  - Subheading: description of the newsletter section
+{%- endcomment -%}
+<div>
+  <div>
+    {% if section.settings.section_title != blank %}
+      <label for="Email">{{ section.settings.section_title | escape }}</label>
+    {% endif %}
+    {% if section.settings.subheading != blank %}
+      <p>{{ section.settings.subheading | escape }}</p>
+    {% endif %}
   </div>
+  {% form 'customer' %}
+    {{ form.errors | default_errors }}
+    {% if form.posted_successfully? %}
+      <p>{{ 'general.newsletter_form.confirmation' | t }}</p>
+    {% else %}
+      <div>
+        <input type="hidden" name="contact[tags]" value="newsletter">
+        <input type="email"
+          name="contact[email]"
+          id="Email"
+          value="{% if customer %}{{ customer.email }}{% endif %}"
+          placeholder="{{ 'general.newsletter_form.email_placeholder' | t }}"
+          autocorrect="off"
+          autocapitalize="off">
+        <button type="submit" name="commit" id="Subscribe">
+          <span>{{ 'general.newsletter_form.submit' | t }}</span>
+        </button>
+      </div>
+    {% endif %}
+  {% endform %}
 </div>
 
 {% schema %}
@@ -50,12 +53,6 @@
         "id": "subheading",
         "label": "Subheading",
         "default": "A short sentence describing what someone will receive by subscribing"
-      },
-      {
-        "id": "show_background",
-        "type": "checkbox",
-        "label": "Show background",
-        "default": true
       },
       {
         "type": "paragraph",


### PR DESCRIPTION
Reference: #8
[Demo store](https://sin7r909t58rmfl9-662601789.shopifypreview.com)

### WHAT are you trying to accomplish with this PR?
I am adding the "Newsletter" section template from `Debut` theme as a starting point in order to see the newest change when I adapt the `starter theme` approach.

### WHY are you choosing this approach?
In order to see the changes when I adapt the "starter theme" way, we need a reference to see what has been changed.

### HOW is this accomplished?
Copied the `newsletter.liquid` from Debut theme.

### Questions
1. Is it necessary to have "Show background" option? I personally think we can remove as it's only for aesthetic purpose
