### PR TITLE
Add announcement bar section

### DIFF
--- a/src/assets/scripts/layout/theme.js
+++ b/src/assets/scripts/layout/theme.js
@@ -12,11 +12,12 @@ import $ from 'jquery';
 import {pageLinkFocus} from '@shopify/theme-a11y';
 import {cookiesEnabled} from '@shopify/theme-cart';
 import {wrapTable, wrapIframe} from '@shopify/theme-rte';
+import sections from '@shopify/theme-sections';
 
 window.slate = window.slate || {};
 window.theme = window.theme || {};
 
-/* = =============== Templates ================ */
+window.theme.sections = sections;
 
 $(document).ready(() => {
   // Common a11y fixes

--- a/src/assets/styles/modules/header.scss
+++ b/src/assets/styles/modules/header.scss
@@ -1,4 +1,4 @@
-/* ================ Site Header ================ */
+/* Header */
 .site-logo {
   display: block;
 

--- a/src/assets/styles/theme.scss
+++ b/src/assets/styles/theme.scss
@@ -25,7 +25,7 @@
 @import './global/blank-states';
 
 /* ================ MODULES ================ */
-@import './modules/site-header';
+@import './modules/header';
 @import './modules/gift-card-template';
 @import './modules/responsive-images';
 @import './modules/hero-banner';

--- a/src/sections/header.liquid
+++ b/src/sections/header.liquid
@@ -5,7 +5,33 @@
     }
   {% endif %}
 </style>
-<div data-section-id="{{ section.id }}" data-section-type="header-section">
+<div data-section-id="{{ section.id }}" data-section-type="header">
+  {%- comment -%}
+    This is a required section for the Shopify Theme Store.
+    It is available in the "Header" section in the theme editor.
+
+    Theme Store required settings
+    - Show announcement
+    - Text: message to announce
+    - Link: link of the announcement bar
+
+    Theme Store optional settings
+    - Home page only: only shows on the index template
+  {%- endcomment -%}
+  {%- if section.settings.announcement_bar_enabled -%}
+    <div>
+      {%- if section.settings.announcement_bar_home_page_only == false or template.name == 'index' -%}
+        {%- if section.settings.announcement_bar_link != blank -%}
+          <a href="{{ section.settings.announcement_bar_link }}">
+            {{ section.settings.announcement_bar_text | escape }}
+          </a>
+        {%- else -%}
+          <p>{{ section.settings.announcement_bar_text | escape }}</p>
+        {%- endif -%}
+      {%- endif -%}
+    </div>
+  {%- endif -%}
+
   <header role="banner">
     {% if template.name == 'index' %}
       <h1 itemscope itemtype="http://schema.org/Organization">
@@ -74,7 +100,6 @@
         <span class="icon-fallback-text">{{ 'general.search.submit' | t }}</span>
       </button>
     </form>
-
   </header>
 
   <nav role="navigation">
@@ -109,6 +134,38 @@
   {
     "name": "Header",
     "settings": [
+      {
+        "type": "header",
+        "content": "Announcement bar"
+      },
+      {
+        "type": "checkbox",
+        "id": "announcement_bar_enabled",
+        "label": "Show announcement",
+        "default": false
+      },
+      {
+        "type": "checkbox",
+        "id": "announcement_bar_home_page_only",
+        "label": "Home page only",
+        "default": true
+      },
+      {
+        "type": "text",
+        "id": "announcement_bar_text",
+        "label": "Announcement text",
+        "default": "Announce something here"
+      },
+      {
+        "type": "url",
+        "id": "announcement_bar_link",
+        "label": "Announcement link",
+        "info": "Optional"
+      },
+      {
+        "type": "header",
+        "content": "Header"
+      },
       {
         "type": "image_picker",
         "id": "logo",


### PR DESCRIPTION
Adds the announcement bar to the header section.

I didn't implement a close button for the announcement bar. Doing so would enforce us to write a decent chunk of JavaScript right out of the box; which might not be useful to all theme developers using this starter theme.

I also renamed the `site-header.scss` to `header.scss` to reflect which section file name it refers to.