### PR TITLE
Add an example of how to import another stylesheet in .scss.liquid

### DIFF
--- a/src/assets/styles/theme.scss.liquid
+++ b/src/assets/styles/theme.scss.liquid
@@ -1,2 +1,6 @@
-// Insert your styles with liquid below.
-// Import additional stylesheets into this sheet using CSS imports:
+/*
+ Insert your styles with liquid below.
+
+ Import additional stylesheets into this sheet using CSS imports:
+   @import url('./global/form.scss');
+*/


### PR DESCRIPTION
Adds an example of how to import additional stylesheets to a `.scss.liquid` file. I had to [previously remove a similar comment because it was breaking the build](https://github.com/Shopify/slate/issues/502). I have since realized that comment wasn't a correct example.