### PR TITLE
Fix CSS compilation due to double quotes

### DIFF
--- a/src/snippets/css-variables.liquid
+++ b/src/snippets/css-variables.liquid
@@ -22,6 +22,6 @@
     --font-body: {{ settings.font_body.family }}, {{ settings.font_body.fallback_families }};
     --font-body-weight: {{ settings.font_body.weight }};
     --font-body-style: {{ settings.font_body.style }};
-    --font-body-bold-weight: {{ font_body_bold.weight | default: "bold" }};
+    --font-body-bold-weight: {{ font_body_bold.weight | default: 'bold' }};
   }
 </style>


### PR DESCRIPTION
CSS compilation started to fail after merging #27 - the culprit are the double quotes surrounded the value for the Liquid filter. Temporary fix is replacing them with single quotes.

An issue has been opened on the Slate repository: https://github.com/Shopify/slate/issues/511.