### PR TITLE
Add rich text section

### DIFF
--- a/src/sections/rich-text.liquid
+++ b/src/sections/rich-text.liquid
@@ -1,0 +1,40 @@
+{%- comment -%}
+  This is a required section for the Shopify Theme Store.
+  It is available when you add "Rich text" section on the Theme Editor.
+
+  Theme Store required settings
+  - Heading: title of the rich text section
+  - Text: description of the rich text section
+{%- endcomment -%}
+<section>
+  {%- if section.settings.title != blank -%}
+    <h2 class="h3">{{ section.settings.title | escape }}</h2>
+  {%- endif -%}
+  {%- if section.settings.text != blank -%}
+    <p>{{ section.settings.text }}</p>
+  {%- endif -%}
+</section>
+
+{% schema %}
+  {
+    "name": "Rich text",
+    "settings": [
+      {
+        "type": "text",
+        "id": "title",
+        "label": "Heading",
+        "default": "Talk about your brand"
+      },
+      {
+        "type": "richtext",
+        "id": "text",
+        "label": "Text",
+        "default": "<p>Use this text to share information about your brand with your customers. Describe a product, share announcements, or welcome customers to your store.</p>"
+      }
+    ],
+    "presets": [{
+        "name": "Rich text",
+        "category": "Text"
+    }]
+  }
+{% endschema %}

--- a/src/sections/rich-text.liquid
+++ b/src/sections/rich-text.liquid
@@ -11,7 +11,7 @@
     <h2 class="h3">{{ section.settings.title | escape }}</h2>
   {%- endif -%}
   {%- if section.settings.text != blank -%}
-    <p>{{ section.settings.text }}</p>
+    <div>{{ section.settings.text }}</div>
   {%- endif -%}
 </section>
 

--- a/src/sections/rich-text.liquid
+++ b/src/sections/rich-text.liquid
@@ -8,10 +8,12 @@
 {%- endcomment -%}
 <section>
   {%- if section.settings.title != blank -%}
-    <h2 class="h3">{{ section.settings.title | escape }}</h2>
+    <h2>{{ section.settings.title | escape }}</h2>
   {%- endif -%}
   {%- if section.settings.text != blank -%}
-    <div>{{ section.settings.text }}</div>
+    <div class="rte">
+      {{ section.settings.text }}
+    </div>
   {%- endif -%}
 </section>
 


### PR DESCRIPTION
Adds the rich text section. Optional settings for this section, which I omitted, are:

1. Wide display
2. Background color
3. Size (small, medium, large)

I do not feel the need to add these for the Starter theme.