### PR TITLE
Remove condition for font face nil check

### DIFF
--- a/src/snippets/css-variables.liquid
+++ b/src/snippets/css-variables.liquid
@@ -5,13 +5,8 @@
   {%- assign font_body_bold = settings.font_body | font_modify: 'weight', 'bolder' -%}
   {%- assign font_body_bold_italic = font_body_bold | font_modify: 'style', 'italic' -%}
 
-  {% if font_body_bold %}
-    {{ font_body_bold | font_face }}
-  {% endif %}
-
-  {% if font_body_bold_italic %}
-    {{ font_body_bold_italic | font_face }}
-  {% endif %}
+  {{ font_body_bold | font_face }}
+  {{ font_body_bold_italic | font_face }}
 
   :root {
     --color-accent: {{ settings.color_accent }};


### PR DESCRIPTION
Based on updates made to the font picker:

>When chaining calls to filters, theme developers have to add multiple checks to make sure they don't get a Liquid error when a font doesn't exist.

@t-kelly @tauthomas01 