### PR TITLE
Add config for cssVarLoaderLiquidPath

### DIFF
--- a/slate.config.js
+++ b/slate.config.js
@@ -8,8 +8,13 @@ const alias = {
 };
 
 module.exports = {
-  extends: {
-    dev: {resolve: {alias}},
-    prod: {resolve: {alias}},
+  slateCssVarLoader: {
+    cssVarLoaderLiquidPath: ['src/snippets/css-variables.liquid'],
+  },
+  slateTools: {
+    extends: {
+      dev: {resolve: {alias}},
+      prod: {resolve: {alias}},
+    },
   },
 };


### PR DESCRIPTION
Followup to https://github.com/Shopify/slate/pull/520

Makes sure we specify that we are declaring our CSS variables inside `snippets/css-variables.liquid`.