### PR TITLE
Fix a11y issues on search page

### DIFF
--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -45,7 +45,15 @@
       "results_for_html": "Din søgning for \"{{ terms }}\" fandt følgende:",
       "title": "Søg efter produkter på vores site",
       "placeholder": "Søg på vores butik",
-      "submit": "Søg"
+      "submit": "Søg",
+      "heading": {
+        "one": "Søgeresultat",
+        "other": "Søgeresultater"
+      },
+      "results_with_count": {
+        "one": "{{ count }} resultat for \"{{ terms }}\"",
+        "other": "{{ count }} resultat for \"{{ terms }}\""
+      }
     },
     "newsletter_form": {
       "newsletter_email": "Deltag i vores mailingliste",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -48,7 +48,15 @@
         "Ihre Suche nach \"{{ terms }}\" hat folgende Ergebnisse hervorgebracht:",
       "title": "Suchen Sie auf unserer Seite nach Produkten",
       "placeholder": "Durchsuchen Sie unseren Shop",
-      "submit": "Suchen"
+      "submit": "Suchen",
+      "heading": {
+        "one": "Suchergebnis",
+        "other": "Suchergebnisse"
+      },
+      "results_with_count": {
+        "one": "{{ count }} Ergebnis für \"{{ terms }}\"",
+        "other": "{{ count }} Ergebnisse für \"{{ terms }}\""
+      }
     },
     "newsletter_form": {
       "newsletter_email": "Im Bilde sein",

--- a/src/locales/en.default.json
+++ b/src/locales/en.default.json
@@ -40,13 +40,17 @@
       }
     },
     "search": {
-      "no_results_html":
-        "Your search for \"{{ terms }}\" did not yield any results.",
-      "results_for_html":
-        "Your search for \"{{ terms }}\" revealed the following:",
       "title": "Search for products on our site",
       "placeholder": "Search our store",
-      "submit": "Search"
+      "submit": "Search",
+      "heading": {
+        "one": "Search result",
+        "other": "Search results"
+      },
+      "results_with_count": {
+        "one": "{{ count }} result for \"{{ terms }}\"",
+        "other": "{{ count }} results for \"{{ terms }}\""
+      }
     },
     "newsletter_form": {
       "newsletter_email": "Join our mailing list",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -47,7 +47,15 @@
         "Su búsqueda de \"{{ terms }}\" muestra lo siguiente:",
       "title": "Buscar productos en nuestro sitio",
       "placeholder": "buscar en nuestra tienda",
-      "submit": "Buscar"
+      "submit": "Buscar",
+      "heading": {
+        "one": "Resultado de búsqueda",
+        "other": "Resultados de la búsqueda"
+      },
+      "results_with_count": {
+        "one": "{{ count }} resultado para \"{{ terms }}\"",
+        "other": "{{ count }} resultados para \"{{ terms }}\""
+      }
     },
     "newsletter_form": {
       "newsletter_email": "Estar en el saber",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -48,7 +48,15 @@
         "Votre recherche pour \"{{ terms }}\" a généré les résultats suivants:",
       "title": "Effectuez une recherche",
       "placeholder": "Rechercher dans la boutique",
-      "submit": "Recherche"
+      "submit": "Recherche",
+      "heading": {
+        "one": "Résultat de la recherche",
+        "other": "Résultats de la recherche"
+      },
+      "results_with_count": {
+        "one": "{{ count }} résultat pour \"{{ terms }}\"",
+        "other": "{{ count }} résultats pour \"{{ terms }}\""
+      }
     },
     "newsletter_form": {
       "newsletter_email": "Soyez au courant",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -48,7 +48,15 @@
         "Uw zoekopdracht naar \"{{ terms }}\" geeft de volgende resultaten:",
       "title": "Zoek naar producten",
       "placeholder": "Zoek in onze winkel",
-      "submit": "Zoeken"
+      "submit": "Zoeken",
+      "heading": {
+        "one": "Zoekresultaat",
+        "other": "Zoekresultaten"
+      },
+      "results_with_count": {
+        "one": "{{ count }} resultaat voor \"{{ terms }}\"",
+        "other": "{{ count }} resultaten voor \"{{ terms }}\""
+      }
     },
     "newsletter_form": {
       "newsletter_email": "Kom bij onze maillijst",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -48,7 +48,15 @@
         "A sua pesquisa por \"{{ terms }}\" teve os seguintes resultados:",
       "title": "Procure produtos no nosso site",
       "placeholder": "Procure na nossa loja",
-      "submit": "Procurar"
+      "submit": "Procurar",
+      "heading": {
+        "one": "Resultado da pesquisa",
+        "other": "Procurar Resultados"
+      },
+      "results_with_count": {
+        "one": "{{ count }} resultado para \"{{ terms }}\"",
+        "other": "{{ count }} resultados para \"{{ terms }}\""
+      }
     },
     "newsletter_form": {
       "newsletter_email": "Assine nossa newsletter",

--- a/src/locales/pt-PT.json
+++ b/src/locales/pt-PT.json
@@ -48,7 +48,15 @@
         "A sua pesquisa por \"{{ terms }}\" teve os seguintes resultados:",
       "title": "Procure produtos no nosso site",
       "placeholder": "Procure na nossa loja",
-      "submit": "Procurar"
+      "submit": "Procurar",
+      "heading": {
+        "one": "Resultado da pesquisa",
+        "other": "Procurar Resultados"
+      },
+      "results_with_count": {
+        "one": "{{ count }} resultado para \"{{ terms }}\"",
+        "other": "{{ count }} resultados para \"{{ terms }}\""
+      }
     },
     "newsletter_form": {
       "newsletter_email": "Esteja por dentro",

--- a/src/templates/search.liquid
+++ b/src/templates/search.liquid
@@ -33,7 +33,7 @@
           <a href="{{ item.url | within: collection }}">
             {% assign featured_image = item.image | default: item.featured_image %}
             {% if featured_image != blank %}
-              {{ featured_image | img_url: '240x240' | img_tag: '' }}
+              {{ featured_image | img_url: '240x240' | img_tag }}
             {% endif %}
             <h3>{{ item.title }}</h3>
           </a>

--- a/src/templates/search.liquid
+++ b/src/templates/search.liquid
@@ -29,53 +29,53 @@
 
 
 {% if search.performed %}
-    <ul>
-      {% for item in search.results %}
-        <li>
-          {% assign featured_image = item.image | default: item.featured_image %}
-          {% if featured_image != blank %}
-            <a href="{{ item.url | within: collection }}" title="{{ item.title | escape }}">
-              {{ featured_image | img_url: '240x240' | img_tag: featured_image.alt }}
-            </a>
-          {% endif %}
+  <ul>
+    {% for item in search.results %}
+      <li>
+        {% assign featured_image = item.image | default: item.featured_image %}
+        {% if featured_image != blank %}
+          <a href="{{ item.url | within: collection }}" title="{{ item.title | escape }}">
+            {{ featured_image | img_url: '240x240' | img_tag: featured_image.alt }}
+          </a>
+        {% endif %}
 
-          <h5>{{ item.title | link_to: item.url }}</h5>
+        <h5>{{ item.title | link_to: item.url }}</h5>
 
-          {% if item.object_type == 'product' %}
-            <p>
-              {% if item.compare_at_price > item.price %}
-                {% if item.price_varies %}
-                  {% assign sale_price = item.price | money %}
-                  {{ 'products.product.on_sale_from_html' | t: price: sale_price }}
-                {% else %}
-                  {{ 'products.product.on_sale' | t }}
-                  <span itemprop="price">{{ item.price | money }}</span>
-                {% endif %}
-                <span class="visually-hidden">{{ 'products.product.regular_price' | t }}</span>
-                <s>{{ item.compare_at_price | money }}</s>
+        {% if item.object_type == 'product' %}
+          <p>
+            {% if item.compare_at_price > item.price %}
+              {% if item.price_varies %}
+                {% assign sale_price = item.price | money %}
+                {{ 'products.product.on_sale_from_html' | t: price: sale_price }}
               {% else %}
-                {% if item.price_varies %}
-                  {% assign price = item.price | money %}
-                  <span itemprop="price">{{ 'products.product.from_text_html' | t: price: price }}</span>
-                {% else %}
-                  <span itemprop="price">{{ item.price | money }}</span>
-                {% endif %}
+                {{ 'products.product.on_sale' | t }}
+                <span itemprop="price">{{ item.price | money }}</span>
               {% endif %}
-              {% unless item.available %}
-              {{ 'products.product.sold_out' | t }}
-              {% endunless %}
-            </p>
-          {% else %}
-            <p>{{ item.content | strip_html | truncatewords: 50 }}</p>
-          {% endif %}
+              <span class="visually-hidden">{{ 'products.product.regular_price' | t }}</span>
+              <s>{{ item.compare_at_price | money }}</s>
+            {% else %}
+              {% if item.price_varies %}
+                {% assign price = item.price | money %}
+                <span itemprop="price">{{ 'products.product.from_text_html' | t: price: price }}</span>
+              {% else %}
+                <span itemprop="price">{{ item.price | money }}</span>
+              {% endif %}
+            {% endif %}
+            {% unless item.available %}
+            {{ 'products.product.sold_out' | t }}
+            {% endunless %}
+          </p>
+        {% else %}
+          <p>{{ item.content | strip_html | truncatewords: 50 }}</p>
+        {% endif %}
 
-        </li>
-      {% endfor %}
-    </ul>
+      </li>
+    {% endfor %}
+  </ul>
 
-    {% if paginate.pages > 1 %}
-      {% include 'pagination' %}
-    {% endif %}
+  {% if paginate.pages > 1 %}
+    {% include 'pagination' %}
   {% endif %}
+{% endif %}
 
 {% endpaginate %}

--- a/src/templates/search.liquid
+++ b/src/templates/search.liquid
@@ -27,55 +27,56 @@
     </button>
   </form>
 
+  <h2 class="visually-hidden">Search results:</h2>
 
-{% if search.performed %}
-  <ul>
-    {% for item in search.results %}
-      <li>
-        {% assign featured_image = item.image | default: item.featured_image %}
-        {% if featured_image != blank %}
-          <a href="{{ item.url | within: collection }}" title="{{ item.title | escape }}">
-            {{ featured_image | img_url: '240x240' | img_tag: featured_image.alt }}
-          </a>
-        {% endif %}
+  {% if search.performed %}
+    <ul>
+      {% for item in search.results %}
+        <li>
+          {% assign featured_image = item.image | default: item.featured_image %}
+          {% if featured_image != blank %}
+            <a href="{{ item.url | within: collection }}" title="{{ item.title | escape }}">
+              {{ featured_image | img_url: '240x240' | img_tag: featured_image.alt }}
+            </a>
+          {% endif %}
 
-        <h5>{{ item.title | link_to: item.url }}</h5>
+          <h3>{{ item.title | link_to: item.url }}</h3>
 
-        {% if item.object_type == 'product' %}
-          <p>
-            {% if item.compare_at_price > item.price %}
-              {% if item.price_varies %}
-                {% assign sale_price = item.price | money %}
-                {{ 'products.product.on_sale_from_html' | t: price: sale_price }}
+          {% if item.object_type == 'product' %}
+            <p>
+              {% if item.compare_at_price > item.price %}
+                {% if item.price_varies %}
+                  {% assign sale_price = item.price | money %}
+                  {{ 'products.product.on_sale_from_html' | t: price: sale_price }}
+                {% else %}
+                  {{ 'products.product.on_sale' | t }}
+                  <span itemprop="price">{{ item.price | money }}</span>
+                {% endif %}
+                <span class="visually-hidden">{{ 'products.product.regular_price' | t }}</span>
+                <s>{{ item.compare_at_price | money }}</s>
               {% else %}
-                {{ 'products.product.on_sale' | t }}
-                <span itemprop="price">{{ item.price | money }}</span>
+                {% if item.price_varies %}
+                  {% assign price = item.price | money %}
+                  <span itemprop="price">{{ 'products.product.from_text_html' | t: price: price }}</span>
+                {% else %}
+                  <span itemprop="price">{{ item.price | money }}</span>
+                {% endif %}
               {% endif %}
-              <span class="visually-hidden">{{ 'products.product.regular_price' | t }}</span>
-              <s>{{ item.compare_at_price | money }}</s>
-            {% else %}
-              {% if item.price_varies %}
-                {% assign price = item.price | money %}
-                <span itemprop="price">{{ 'products.product.from_text_html' | t: price: price }}</span>
-              {% else %}
-                <span itemprop="price">{{ item.price | money }}</span>
-              {% endif %}
-            {% endif %}
-            {% unless item.available %}
-            {{ 'products.product.sold_out' | t }}
-            {% endunless %}
-          </p>
-        {% else %}
-          <p>{{ item.content | strip_html | truncatewords: 50 }}</p>
-        {% endif %}
+              {% unless item.available %}
+              {{ 'products.product.sold_out' | t }}
+              {% endunless %}
+            </p>
+          {% else %}
+            <p>{{ item.content | strip_html | truncatewords: 50 }}</p>
+          {% endif %}
 
-      </li>
-    {% endfor %}
-  </ul>
+        </li>
+      {% endfor %}
+    </ul>
 
-  {% if paginate.pages > 1 %}
-    {% include 'pagination' %}
+    {% if paginate.pages > 1 %}
+      {% include 'pagination' %}
+    {% endif %}
   {% endif %}
-{% endif %}
 
 {% endpaginate %}

--- a/src/templates/search.liquid
+++ b/src/templates/search.liquid
@@ -2,7 +2,7 @@
 
   <h1>
     {% if search.performed %}
-      <span class="visually-hidden">{{ 'general.search.heading' | t }}:</span>
+      <span class="visually-hidden">{{ 'general.search.heading' | t: count: search.results_count }}:</span>
         {{ 'general.search.results_with_count' | t: terms: search.terms, count: search.results_count }}
     {% else %}
       {{ 'general.search.title' | t }}
@@ -24,7 +24,7 @@
     </button>
   </form>
 
-  <h2 class="visually-hidden">{{ 'general.search.heading' | t }}</h2>
+  <h2 class="visually-hidden">{{ 'general.search.heading' | t: count: search.results_count }}</h2>
 
   {% if search.performed %}
     <ul>

--- a/src/templates/search.liquid
+++ b/src/templates/search.liquid
@@ -2,11 +2,8 @@
 
   <h1>
     {% if search.performed %}
-      {% if search.results_count == 0 %}
-        {{ 'general.search.no_results_html' | t: terms: search.terms }}
-      {% else %}
-        {{ 'general.search.results_for_html' | t: terms: search.terms }}
-      {% endif %}
+      <span class="visually-hidden">{{ 'general.search.heading' | t: count: search.results_count }}:</span>
+        {{ 'general.search.results_with_count' | t: terms: search.terms, count: search.results_count }}
     {% else %}
       {{ 'general.search.title' | t }}
     {% endif %}
@@ -27,7 +24,7 @@
     </button>
   </form>
 
-  <h2 class="visually-hidden">Search results:</h2>
+  <h2 class="visually-hidden">{{ 'general.search.heading' | t: count: search.results_count }}</h2>
 
   {% if search.performed %}
     <ul>

--- a/src/templates/search.liquid
+++ b/src/templates/search.liquid
@@ -2,7 +2,7 @@
 
   <h1>
     {% if search.performed %}
-      <span class="visually-hidden">{{ 'general.search.heading' | t: count: search.results_count }}:</span>
+      <span class="visually-hidden">{{ 'general.search.heading' | t }}:</span>
         {{ 'general.search.results_with_count' | t: terms: search.terms, count: search.results_count }}
     {% else %}
       {{ 'general.search.title' | t }}
@@ -24,7 +24,7 @@
     </button>
   </form>
 
-  <h2 class="visually-hidden">{{ 'general.search.heading' | t: count: search.results_count }}</h2>
+  <h2 class="visually-hidden">{{ 'general.search.heading' | t }}</h2>
 
   {% if search.performed %}
     <ul>

--- a/src/templates/search.liquid
+++ b/src/templates/search.liquid
@@ -30,15 +30,13 @@
     <ul>
       {% for item in search.results %}
         <li>
-          {% assign featured_image = item.image | default: item.featured_image %}
-          {% if featured_image != blank %}
-            <a href="{{ item.url | within: collection }}" title="{{ item.title | escape }}">
-              {{ featured_image | img_url: '240x240' | img_tag: featured_image.alt }}
-            </a>
-          {% endif %}
-
-          <h3>{{ item.title | link_to: item.url }}</h3>
-
+          <a href="{{ item.url | within: collection }}">
+            {% assign featured_image = item.image | default: item.featured_image %}
+            {% if featured_image != blank %}
+              {{ featured_image | img_url: '240x240' | img_tag: '' }}
+            {% endif %}
+            <h3>{{ item.title }}</h3>
+          </a>
           {% if item.object_type == 'product' %}
             <p>
               {% if item.compare_at_price > item.price %}


### PR DESCRIPTION
I updated the search template with some best practices regarding accessibility.

### Updates
- Update the title from `Your search for "terms" revealed the following` to `XX results for "terms"` to know how many results you got from your search directly.
- Updated the headings to have a better structure (`h1`->`h2`->`h3` instead of `h1`->`h5`) 
- Regrouped the `img` and `<h3>` under the same link to avoid link duplication.
- Removed some unnecessary attribute like `title` on anchor tags