### PR TITLE
Fix "no results" search

### DIFF
--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -40,9 +40,6 @@
       }
     },
     "search": {
-      "no_results_html":
-        "Din søgning for \"{{ terms }}\" fandt ikke nogle resultater.",
-      "results_for_html": "Din søgning for \"{{ terms }}\" fandt følgende:",
       "title": "Søg efter produkter på vores site",
       "placeholder": "Søg på vores butik",
       "submit": "Søg",
@@ -53,7 +50,8 @@
       "results_with_count": {
         "one": "{{ count }} resultat for \"{{ terms }}\"",
         "other": "{{ count }} resultat for \"{{ terms }}\""
-      }
+      },
+      "no_results_html": "Prøv et andet søgeord eller gå tilbage til <a href=\"/\">hjemmesiden</a>."
     },
     "newsletter_form": {
       "newsletter_email": "Deltag i vores mailingliste",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -42,10 +42,6 @@
       }
     },
     "search": {
-      "no_results_html":
-        "Ihre Suche nach \"{{ terms }}\" hat keine Ergebnisse hervorgebracht.",
-      "results_for_html":
-        "Ihre Suche nach \"{{ terms }}\" hat folgende Ergebnisse hervorgebracht:",
       "title": "Suchen Sie auf unserer Seite nach Produkten",
       "placeholder": "Durchsuchen Sie unseren Shop",
       "submit": "Suchen",
@@ -56,7 +52,8 @@
       "results_with_count": {
         "one": "{{ count }} Ergebnis für \"{{ terms }}\"",
         "other": "{{ count }} Ergebnisse für \"{{ terms }}\""
-      }
+      },
+      "no_results_html": "Bitte versuchen Sie einen anderen Suchbegriff oder gehen Sie zurück zur <a href=\"/\">Startseite</a>."
     },
     "newsletter_form": {
       "newsletter_email": "Im Bilde sein",

--- a/src/locales/en.default.json
+++ b/src/locales/en.default.json
@@ -50,7 +50,8 @@
       "results_with_count": {
         "one": "{{ count }} result for \"{{ terms }}\"",
         "other": "{{ count }} results for \"{{ terms }}\""
-      }
+      },
+      "no_results_html": "Please try a different search term or go back to the <a href=\"/\">homepage</a>."
     },
     "newsletter_form": {
       "newsletter_email": "Join our mailing list",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -42,9 +42,6 @@
       }
     },
     "search": {
-      "no_results_html": "Su búsqueda de \"{{ terms }}\" no tuvo resultados.",
-      "results_for_html":
-        "Su búsqueda de \"{{ terms }}\" muestra lo siguiente:",
       "title": "Buscar productos en nuestro sitio",
       "placeholder": "buscar en nuestra tienda",
       "submit": "Buscar",
@@ -55,7 +52,8 @@
       "results_with_count": {
         "one": "{{ count }} resultado para \"{{ terms }}\"",
         "other": "{{ count }} resultados para \"{{ terms }}\""
-      }
+      },
+      "no_results_html": "Intente con un término de búsqueda diferente o regrese a la <a href=\"/\">página de inicio</a>."
     },
     "newsletter_form": {
       "newsletter_email": "Estar en el saber",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -42,10 +42,6 @@
       }
     },
     "search": {
-      "no_results_html":
-        "Votre recherche pour \"{{ terms }}\" n'a pas généré de résultats.",
-      "results_for_html":
-        "Votre recherche pour \"{{ terms }}\" a généré les résultats suivants:",
       "title": "Effectuez une recherche",
       "placeholder": "Rechercher dans la boutique",
       "submit": "Recherche",
@@ -56,7 +52,8 @@
       "results_with_count": {
         "one": "{{ count }} résultat pour \"{{ terms }}\"",
         "other": "{{ count }} résultats pour \"{{ terms }}\""
-      }
+      },
+      "no_results_html": "Veuillez essayer un terme de recherche différent ou revenir à la <a href=\"/\">page d'accueil</a>."
     },
     "newsletter_form": {
       "newsletter_email": "Soyez au courant",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -42,10 +42,6 @@
       }
     },
     "search": {
-      "no_results_html":
-        "Uw zoekopdracht naar \"{{ terms }}\" heeft geen resultaten opgeleverd.",
-      "results_for_html":
-        "Uw zoekopdracht naar \"{{ terms }}\" geeft de volgende resultaten:",
       "title": "Zoek naar producten",
       "placeholder": "Zoek in onze winkel",
       "submit": "Zoeken",
@@ -56,7 +52,8 @@
       "results_with_count": {
         "one": "{{ count }} resultaat voor \"{{ terms }}\"",
         "other": "{{ count }} resultaten voor \"{{ terms }}\""
-      }
+      },
+      "no_results_html": "Probeer een ander trefwoord of ga terug naar de <a href=\"/\">startpagina</a>."
     },
     "newsletter_form": {
       "newsletter_email": "Kom bij onze maillijst",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -42,10 +42,6 @@
       }
     },
     "search": {
-      "no_results_html":
-        "A sua pesquisa por \"{{ terms }}\" não teve resultados.",
-      "results_for_html":
-        "A sua pesquisa por \"{{ terms }}\" teve os seguintes resultados:",
       "title": "Procure produtos no nosso site",
       "placeholder": "Procure na nossa loja",
       "submit": "Procurar",
@@ -56,7 +52,8 @@
       "results_with_count": {
         "one": "{{ count }} resultado para \"{{ terms }}\"",
         "other": "{{ count }} resultados para \"{{ terms }}\""
-      }
+      },
+      "no_results_html": "Por favor, tente um termo de pesquisa diferente ou volte para a <a href=\"/\">página inicial</a>."
     },
     "newsletter_form": {
       "newsletter_email": "Assine nossa newsletter",

--- a/src/locales/pt-PT.json
+++ b/src/locales/pt-PT.json
@@ -42,10 +42,6 @@
       }
     },
     "search": {
-      "no_results_html":
-        "A sua pesquisa por \"{{ terms }}\" não teve resultados.",
-      "results_for_html":
-        "A sua pesquisa por \"{{ terms }}\" teve os seguintes resultados:",
       "title": "Procure produtos no nosso site",
       "placeholder": "Procure na nossa loja",
       "submit": "Procurar",
@@ -56,7 +52,8 @@
       "results_with_count": {
         "one": "{{ count }} resultado para \"{{ terms }}\"",
         "other": "{{ count }} resultados para \"{{ terms }}\""
-      }
+      },
+      "no_results_html": "Por favor, tente um termo de pesquisa diferente ou volte para a <a href=\"/\">página inicial</a>."
     },
     "newsletter_form": {
       "newsletter_email": "Esteja por dentro",

--- a/src/templates/search.liquid
+++ b/src/templates/search.liquid
@@ -24,53 +24,56 @@
     </button>
   </form>
 
-  <h2 class="visually-hidden">{{ 'general.search.heading' | t: count: search.results_count }}</h2>
-
   {% if search.performed %}
-    <ul>
-      {% for item in search.results %}
-        <li>
-          <a href="{{ item.url | within: collection }}">
-            {% assign featured_image = item.image | default: item.featured_image %}
-            {% if featured_image != blank %}
-              {{ featured_image | img_url: '240x240' | img_tag }}
-            {% endif %}
-            <h3>{{ item.title }}</h3>
-          </a>
-          {% if item.object_type == 'product' %}
-            <p>
-              {% if item.compare_at_price > item.price %}
-                {% if item.price_varies %}
-                  {% assign sale_price = item.price | money %}
-                  {{ 'products.product.on_sale_from_html' | t: price: sale_price }}
-                {% else %}
-                  {{ 'products.product.on_sale' | t }}
-                  <span itemprop="price">{{ item.price | money }}</span>
-                {% endif %}
-                <span class="visually-hidden">{{ 'products.product.regular_price' | t }}</span>
-                <s>{{ item.compare_at_price | money }}</s>
-              {% else %}
-                {% if item.price_varies %}
-                  {% assign price = item.price | money %}
-                  <span itemprop="price">{{ 'products.product.from_text_html' | t: price: price }}</span>
-                {% else %}
-                  <span itemprop="price">{{ item.price | money }}</span>
-                {% endif %}
+    {% if search.results_count == 0 %}
+      <p>{{ 'general.search.no_results' | t: terms: search.terms }}</p>
+    {% else %}
+      <h2 class="visually-hidden">{{ 'general.search.heading' | t: count: search.results_count }}</h2>
+      <ul>
+        {% for item in search.results %}
+          <li>
+            <a href="{{ item.url | within: collection }}">
+              {% assign featured_image = item.image | default: item.featured_image %}
+              {% if featured_image != blank %}
+                {{ featured_image | img_url: '240x240' | img_tag }}
               {% endif %}
-              {% unless item.available %}
-              {{ 'products.product.sold_out' | t }}
-              {% endunless %}
-            </p>
-          {% else %}
-            <p>{{ item.content | strip_html | truncatewords: 50 }}</p>
-          {% endif %}
+              <h3>{{ item.title }}</h3>
+            </a>
+            {% if item.object_type == 'product' %}
+              <p>
+                {% if item.compare_at_price > item.price %}
+                  {% if item.price_varies %}
+                    {% assign sale_price = item.price | money %}
+                    {{ 'products.product.on_sale_from_html' | t: price: sale_price }}
+                  {% else %}
+                    {{ 'products.product.on_sale' | t }}
+                    <span itemprop="price">{{ item.price | money }}</span>
+                  {% endif %}
+                  <span class="visually-hidden">{{ 'products.product.regular_price' | t }}</span>
+                  <s>{{ item.compare_at_price | money }}</s>
+                {% else %}
+                  {% if item.price_varies %}
+                    {% assign price = item.price | money %}
+                    <span itemprop="price">{{ 'products.product.from_text_html' | t: price: price }}</span>
+                  {% else %}
+                    <span itemprop="price">{{ item.price | money }}</span>
+                  {% endif %}
+                {% endif %}
+                {% unless item.available %}
+                {{ 'products.product.sold_out' | t }}
+                {% endunless %}
+              </p>
+            {% else %}
+              <p>{{ item.content | strip_html | truncatewords: 50 }}</p>
+            {% endif %}
 
-        </li>
-      {% endfor %}
-    </ul>
+          </li>
+        {% endfor %}
+      </ul>
 
-    {% if paginate.pages > 1 %}
-      {% include 'pagination' %}
+      {% if paginate.pages > 1 %}
+        {% include 'pagination' %}
+      {% endif %}
     {% endif %}
   {% endif %}
 

--- a/src/templates/search.liquid
+++ b/src/templates/search.liquid
@@ -26,7 +26,7 @@
 
   {% if search.performed %}
     {% if search.results_count == 0 %}
-      <p>{{ 'general.search.no_results' | t: terms: search.terms }}</p>
+      <p>{{ 'general.search.no_results_html' | t: terms: search.terms }}</p>
     {% else %}
       <h2 class="visually-hidden">{{ 'general.search.heading' | t: count: search.results_count }}</h2>
       <ul>


### PR DESCRIPTION
- Added a new condition to check if there's `zero` result and moved some elements around
- Added a basic status message if so with translations
- Remove unused `results_for_html` translation key

[Demo store](https://9256b6i4ptu82lt5-22591287.shopifypreview.com/search?q=aafea)