### PR TITLE
Add accessibility improvements in blog post section

### DIFF
--- a/src/assets/styles/sections/blog-posts.scss
+++ b/src/assets/styles/sections/blog-posts.scss
@@ -1,12 +1,11 @@
 .blog-post {
   display: flex;
   flex-wrap: wrap;
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
 .blog-post__item {
   flex: 1 1 percentage(1 / 3);
-}
-
-.blog-post__title {
-  flex-basis: 100%;
 }

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -51,7 +51,8 @@
         "one": "{{ count }} resultat for \"{{ terms }}\"",
         "other": "{{ count }} resultat for \"{{ terms }}\""
       },
-      "no_results_html": "Prøv et andet søgeord eller gå tilbage til <a href=\"/\">hjemmesiden</a>."
+      "no_results_html":
+        "Prøv et andet søgeord eller gå tilbage til <a href=\"/\">hjemmesiden</a>."
     },
     "newsletter_form": {
       "newsletter_email": "Deltag i vores mailingliste",
@@ -65,6 +66,7 @@
       "author_on_date_html": "Skrevet af {{ author }} den {{ date }}",
       "comment_meta_html": "{{ author }} den {{ date }}",
       "read_more": "Læs mere",
+      "read_more_title": "Læs mere: {{ title }}",
       "by_author": "af {{ author }}"
     },
     "comments": {

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -67,7 +67,8 @@
       "comment_meta_html": "{{ author }} den {{ date }}",
       "read_more": "Læs mere",
       "read_more_title": "Læs mere: {{ title }}",
-      "by_author": "af {{ author }}"
+      "by_author": "af {{ author }}",
+      "tags": "Tags"
     },
     "comments": {
       "title": "Skriv en kommentar",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -53,7 +53,8 @@
         "one": "{{ count }} Ergebnis für \"{{ terms }}\"",
         "other": "{{ count }} Ergebnisse für \"{{ terms }}\""
       },
-      "no_results_html": "Bitte versuchen Sie einen anderen Suchbegriff oder gehen Sie zurück zur <a href=\"/\">Startseite</a>."
+      "no_results_html":
+        "Bitte versuchen Sie einen anderen Suchbegriff oder gehen Sie zurück zur <a href=\"/\">Startseite</a>."
     },
     "newsletter_form": {
       "newsletter_email": "Im Bilde sein",
@@ -67,6 +68,7 @@
       "author_on_date_html": "Geposted von {{ author }} am {{ date }}",
       "comment_meta_html": "{{ author }} am {{ date }}",
       "read_more": "Weiterlesen",
+      "read_more_title": "Weiterlesen: {{ title }}",
       "by_author": "von {{ author }}"
     },
     "comments": {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -69,7 +69,8 @@
       "comment_meta_html": "{{ author }} am {{ date }}",
       "read_more": "Weiterlesen",
       "read_more_title": "Weiterlesen: {{ title }}",
-      "by_author": "von {{ author }}"
+      "by_author": "von {{ author }}",
+      "tags": "Stichworte"
     },
     "comments": {
       "title": "Hinterlassen Sie einen Kommentar",

--- a/src/locales/en.default.json
+++ b/src/locales/en.default.json
@@ -66,7 +66,8 @@
       "comment_meta_html": "{{ author }} on {{ date }}",
       "read_more": "Read more",
       "read_more_title": "Read more: {{ title }}",
-      "by_author": "by {{ author }}"
+      "by_author": "by {{ author }}",
+      "tags": "Tags"
     },
     "comments": {
       "title": "Leave a comment",

--- a/src/locales/en.default.json
+++ b/src/locales/en.default.json
@@ -65,6 +65,7 @@
       "author_on_date_html": "Posted by {{ author }} on {{ date }}",
       "comment_meta_html": "{{ author }} on {{ date }}",
       "read_more": "Read more",
+      "read_more_title": "Read more: {{ title }}",
       "by_author": "by {{ author }}"
     },
     "comments": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -53,7 +53,8 @@
         "one": "{{ count }} resultado para \"{{ terms }}\"",
         "other": "{{ count }} resultados para \"{{ terms }}\""
       },
-      "no_results_html": "Intente con un término de búsqueda diferente o regrese a la <a href=\"/\">página de inicio</a>."
+      "no_results_html":
+        "Intente con un término de búsqueda diferente o regrese a la <a href=\"/\">página de inicio</a>."
     },
     "newsletter_form": {
       "newsletter_email": "Estar en el saber",
@@ -67,6 +68,7 @@
       "author_on_date_html": "Publicado por {{ author }} en {{ date }}",
       "comment_meta_html": "{{ author }} en {{ date }}",
       "read_more": "Leer más",
+      "read_more_title": "Leer más: {{ title }}",
       "by_author": "por {{ author }}"
     },
     "comments": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -69,7 +69,8 @@
       "comment_meta_html": "{{ author }} en {{ date }}",
       "read_more": "Leer más",
       "read_more_title": "Leer más: {{ title }}",
-      "by_author": "por {{ author }}"
+      "by_author": "por {{ author }}",
+      "tags": "Etiquetas"
     },
     "comments": {
       "title": "Dejar un comentario",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -69,7 +69,8 @@
       "comment_meta_html": "{{ author }} le {{ date }}",
       "read_more": "Plus",
       "read_more_title": "Plus: {{ title }}",
-      "by_author": "par {{ author }}"
+      "by_author": "par {{ author }}",
+      "tags": "Mots clés"
     },
     "comments": {
       "title": "Laissez un commentaire",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -53,7 +53,8 @@
         "one": "{{ count }} résultat pour \"{{ terms }}\"",
         "other": "{{ count }} résultats pour \"{{ terms }}\""
       },
-      "no_results_html": "Veuillez essayer un terme de recherche différent ou revenir à la <a href=\"/\">page d'accueil</a>."
+      "no_results_html":
+        "Veuillez essayer un terme de recherche différent ou revenir à la <a href=\"/\">page d'accueil</a>."
     },
     "newsletter_form": {
       "newsletter_email": "Soyez au courant",
@@ -67,6 +68,7 @@
       "author_on_date_html": "Publié par {{ author }} le {{ date }}",
       "comment_meta_html": "{{ author }} le {{ date }}",
       "read_more": "Plus",
+      "read_more_title": "Plus: {{ title }}",
       "by_author": "par {{ author }}"
     },
     "comments": {

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -53,7 +53,8 @@
         "one": "{{ count }} resultaat voor \"{{ terms }}\"",
         "other": "{{ count }} resultaten voor \"{{ terms }}\""
       },
-      "no_results_html": "Probeer een ander trefwoord of ga terug naar de <a href=\"/\">startpagina</a>."
+      "no_results_html":
+        "Probeer een ander trefwoord of ga terug naar de <a href=\"/\">startpagina</a>."
     },
     "newsletter_form": {
       "newsletter_email": "Kom bij onze maillijst",
@@ -67,6 +68,7 @@
       "author_on_date_html": "Geplaats door {{ author }} op {{ date }}",
       "comment_meta_html": "{{ author }} op {{ date }}",
       "read_more": "Lees verder",
+      "read_more_title": "Lees verder: {{ title }}",
       "by_author": "door {{ author }}"
     },
     "comments": {

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -69,7 +69,8 @@
       "comment_meta_html": "{{ author }} op {{ date }}",
       "read_more": "Lees verder",
       "read_more_title": "Lees verder: {{ title }}",
-      "by_author": "door {{ author }}"
+      "by_author": "door {{ author }}",
+      "tags": "Labels"
     },
     "comments": {
       "title": "Laat een reactie achter",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -69,7 +69,8 @@
       "comment_meta_html": "{{ author }} em {{ date }}",
       "read_more": "Saiba mais",
       "read_more_title": "Saiba mais: {{ title }}",
-      "by_author": "por {{ author }}"
+      "by_author": "por {{ author }}",
+      "tags": "Tag"
     },
     "comments": {
       "title": "Deixe um comentário",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -53,7 +53,8 @@
         "one": "{{ count }} resultado para \"{{ terms }}\"",
         "other": "{{ count }} resultados para \"{{ terms }}\""
       },
-      "no_results_html": "Por favor, tente um termo de pesquisa diferente ou volte para a <a href=\"/\">página inicial</a>."
+      "no_results_html":
+        "Por favor, tente um termo de pesquisa diferente ou volte para a <a href=\"/\">página inicial</a>."
     },
     "newsletter_form": {
       "newsletter_email": "Assine nossa newsletter",
@@ -67,6 +68,7 @@
       "author_on_date_html": "Postado por {{ author }} em {{ date }}",
       "comment_meta_html": "{{ author }} em {{ date }}",
       "read_more": "Saiba mais",
+      "read_more_title": "Saiba mais: {{ title }}",
       "by_author": "por {{ author }}"
     },
     "comments": {

--- a/src/locales/pt-PT.json
+++ b/src/locales/pt-PT.json
@@ -69,7 +69,8 @@
       "comment_meta_html": "{{ author }} em {{ date }}",
       "read_more": "Saiba mais",
       "read_more_title": "Ler mais: {{ title }}",
-      "by_author": "por {{ author }}"
+      "by_author": "por {{ author }}",
+      "tags": "Tag"
     },
     "comments": {
       "title": "Deixe um comentário",

--- a/src/locales/pt-PT.json
+++ b/src/locales/pt-PT.json
@@ -53,7 +53,8 @@
         "one": "{{ count }} resultado para \"{{ terms }}\"",
         "other": "{{ count }} resultados para \"{{ terms }}\""
       },
-      "no_results_html": "Por favor, tente um termo de pesquisa diferente ou volte para a <a href=\"/\">página inicial</a>."
+      "no_results_html":
+        "Por favor, tente um termo de pesquisa diferente ou volte para a <a href=\"/\">página inicial</a>."
     },
     "newsletter_form": {
       "newsletter_email": "Esteja por dentro",
@@ -67,6 +68,7 @@
       "author_on_date_html": "Postado por {{ author }} em {{ date }}",
       "comment_meta_html": "{{ author }} em {{ date }}",
       "read_more": "Saiba mais",
+      "read_more_title": "Ler mais: {{ title }}",
       "by_author": "por {{ author }}"
     },
     "comments": {

--- a/src/sections/blog-posts.liquid
+++ b/src/sections/blog-posts.liquid
@@ -11,74 +11,75 @@
   - Show author
   - Show date
 {%- endcomment -%}
-<section class="blog-post">
+<section>
   {% if section.settings.title != blank %}
-    <h2 class="blog-post__title">{{ section.settings.title | escape }}</h2>
+    <h2>{{ section.settings.title | escape }}</h2>
   {% endif %}
 
   {%- assign blog = blogs[section.settings.blog] -%}
 
-  {% for article in blog.articles limit: section.settings.post_limit %}
-    <div class="blog-post__item">
-      {% if article.image %}
+  <ul class="blog-post">
+    {% for article in blog.articles limit: section.settings.post_limit %}
+      <li class="blog-post__item">
         <a href="{{ article.url }}">
-          {% include 'responsive-image' with
-              image: article.image,
-              max_width: 400,
-              max_height: 400
-          %}
+          {% if article.image %}
+            {% include 'responsive-image' with
+                image: article.image,
+                max_width: 400,
+                max_height: 400
+            %}
+          {% endif %}
+          <h2>{{ article.title }}</h2>
         </a>
-      {% endif %}
-
-      <div>
-        <h2>
-          <a href="{{ article.url }}">{{ article.title }}</a>
-        </h2>
-
-        {% if section.settings.blog_show_author %}
-          <span>{{ 'blogs.article.by_author' | t: author: article.author }}</span>
-        {% endif %}
-
-        {% if section.settings.blog_show_date %}
-          <p>
-            {{ article.published_at | time_tag: format: 'month_day_year' }}
-          </p>
-        {% endif %}
 
         <div>
-          {% if article.excerpt.size > 0 %}
-            {{ article.excerpt }}
-          {% else %}
-            {{ article.content | strip_html | truncate: 150 }}
+          {% if section.settings.blog_show_author %}
+            <span>{{ 'blogs.article.by_author' | t: author: article.author }}</span>
           {% endif %}
+
+          {% if section.settings.blog_show_date %}
+            <p>
+              {{ article.published_at | time_tag: format: 'month_day_year' }}
+            </p>
+          {% endif %}
+
+          <div>
+            {% if article.excerpt.size > 0 %}
+              {{ article.excerpt }}
+            {% else %}
+              {{ article.content | strip_html | truncate: 150 }}
+            {% endif %}
+          </div>
+
+          {% if article.tags.size > 0 %}
+            <ul>
+              {% for tag in article.tags %}
+                <li><a href="{{ blog.url }}/tagged/{{ tag | handle }}">{{ tag }}</a></li>
+              {% endfor %}
+            </ul>
+          {% endif %}
+
+          <a href="{{ article.url }}" aria-label="{{ 'blogs.article.read_more_title' | t: title: article.title }}">{{ 'blogs.article.read_more' | t }}</a>
         </div>
+      </li>
+    {% else %}
+      {% for i in (1..section.settings.post_limit) %}
+        <li class="blog-post__item">
+          <h3>
+            <a href="#">{{ 'homepage.onboarding.blog_title' | t }}</a>
+          </h3>
 
-        {% if article.tags.size > 0 %}
-          {% for tag in article.tags %}
-            <a href="{{ blog.url }}/tagged/{{ tag | handle }}">{{ tag }}</a>
-          {% endfor %}
-        {% endif %}
+          {% if section.settings.blog_show_author %}
+            <span>{{ 'homepage.onboarding.blog_author' | t }}</span>
+          {% endif %}
 
-        <a href="{{ article.url }}">{{ 'blogs.article.read_more' | t }}</a>
-      </div>
-    </div>
-  {% else %}
-    {% for i in (1..section.settings.post_limit) %}
-      <div class="blog-post__item">
-        <h3>
-          <a href="#">{{ 'homepage.onboarding.blog_title' | t }}</a>
-        </h3>
+          <div>{{ 'homepage.onboarding.blog_excerpt' | t }}</div>
 
-        {% if section.settings.blog_show_author %}
-          <span>{{ 'homepage.onboarding.blog_author' | t }}</span>
-        {% endif %}
-
-        <div>{{ 'homepage.onboarding.blog_excerpt' | t }}</div>
-
-        <a href="#">{{ 'blogs.article.read_more' | t }}</a>
-      </div>
+          <a href="#">{{ 'blogs.article.read_more' | t }}</a>
+        </li>
+      {% endfor %}
     {% endfor %}
-  {% endfor %}
+  </ul>
 </section>
 
 {% schema %}

--- a/src/sections/blog-posts.liquid
+++ b/src/sections/blog-posts.liquid
@@ -19,7 +19,7 @@
   {%- assign blog = blogs[section.settings.blog] -%}
 
   {%- comment -%}
-    Due to accessibility requirement, the Blog entries list functions
+    Due to accessibility requirements, the Blog entries list functions
     as a list of content items. Non-visual users will expect lists of content
     to appear in a list structure, allowing for easier understanding and navigation of list items.
   {%- endcomment -%}
@@ -27,7 +27,7 @@
     {% for article in blog.articles limit: section.settings.post_limit %}
       <li class="blog-post__item">
         {%- comment -%}
-          Due to accessibility requirement, we are regrouping all logical elements into the <a> element.
+          Due to accessibility requirements, we are regrouping all logical elements into the <a> element.
           If a screen reader user is tabbing through the page, or browsing by links on the page with duplicated links,
           they will appear identical which may lead to a confusing user experience.
         {%- endcomment -%}

--- a/src/sections/blog-posts.liquid
+++ b/src/sections/blog-posts.liquid
@@ -18,9 +18,19 @@
 
   {%- assign blog = blogs[section.settings.blog] -%}
 
+  {%- comment -%}
+    Due to accessibility requirement, the Blog entries list functions
+    as a list of content items. Non-visual users will expect lists of content
+    to appear in a list structure, allowing for easier understanding and navigation of list items.
+  {%- endcomment -%}
   <ul class="blog-post">
     {% for article in blog.articles limit: section.settings.post_limit %}
       <li class="blog-post__item">
+        {%- comment -%}
+          Due to accessibility requirement, we are regrouping all logical elements into the <a> element.
+          If a screen reader user is tabbing through the page, or browsing by links on the page with duplicated links,
+          they will appear identical which may lead to a confusing user experience.
+        {%- endcomment -%}
         <a href="{{ article.url }}">
           {% if article.image %}
             {% include 'responsive-image' with
@@ -52,6 +62,11 @@
           </div>
 
           {% if article.tags.size > 0 %}
+            {%- comment -%}
+              The Tag link list functions as a list of content items.
+              Non-visual users will expect lists of content to appear
+              in a list structure, allowing for easier understanding and navigation of list items.
+            {%- endcomment -%}
             <ul>
               {% for tag in article.tags %}
                 <li><a href="{{ blog.url }}/tagged/{{ tag | handle }}">{{ tag }}</a></li>

--- a/src/sections/blog-posts.liquid
+++ b/src/sections/blog-posts.liquid
@@ -29,7 +29,7 @@
                 max_height: 400
             %}
           {% endif %}
-          <h2>{{ article.title }}</h2>
+          <h3>{{ article.title }}</h3>
         </a>
 
         <div>

--- a/src/sections/blog-posts.liquid
+++ b/src/sections/blog-posts.liquid
@@ -67,7 +67,7 @@
               Non-visual users will expect lists of content to appear
               in a list structure, allowing for easier understanding and navigation of list items.
             {%- endcomment -%}
-            <ul>
+            <ul aria-label="{{ 'blogs.article.tags' | t }}">
               {% for tag in article.tags %}
                 <li><a href="{{ blog.url }}/tagged/{{ tag | handle }}">{{ tag }}</a></li>
               {% endfor %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -182,16 +182,16 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@shopify/html-webpack-liquid-asset-tags-plugin@^1.0.0-alpha.29":
-  version "1.0.0-alpha.29"
-  resolved "https://registry.yarnpkg.com/@shopify/html-webpack-liquid-asset-tags-plugin/-/html-webpack-liquid-asset-tags-plugin-1.0.0-alpha.29.tgz#b6d92e072646a7b294588d4940eaf19a879f4938"
+"@shopify/html-webpack-liquid-asset-tags-plugin@^1.0.0-beta.1":
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@shopify/html-webpack-liquid-asset-tags-plugin/-/html-webpack-liquid-asset-tags-plugin-1.0.0-beta.1.tgz#d077b589a4d0cd537f70dbee81b202d5b44f1d14"
 
-"@shopify/slate-analytics@^1.0.0-alpha.29":
-  version "1.0.0-alpha.29"
-  resolved "https://registry.yarnpkg.com/@shopify/slate-analytics/-/slate-analytics-1.0.0-alpha.29.tgz#dd7813cafd32d85399a14cdfc0262df14d80de3e"
+"@shopify/slate-analytics@^1.0.0-beta.1":
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@shopify/slate-analytics/-/slate-analytics-1.0.0-beta.1.tgz#7027bf59589b669b96f29195c41ba86ade02fdb4"
   dependencies:
-    "@shopify/slate-error" "^1.0.0-alpha.29"
-    "@shopify/slate-rc" "^1.0.0-alpha.29"
+    "@shopify/slate-error" "^1.0.0-beta.1"
+    "@shopify/slate-rc" "^1.0.0-beta.1"
     axios "^0.18.0"
     chalk "^2.3.0"
     inquirer "^5.0.1"
@@ -199,53 +199,53 @@
     uuid "^3.2.1"
     word-wrap "^1.2.3"
 
-"@shopify/slate-config@^1.0.0-alpha.29":
-  version "1.0.0-alpha.29"
-  resolved "https://registry.yarnpkg.com/@shopify/slate-config/-/slate-config-1.0.0-alpha.29.tgz#c6772f7c99998966aeeb1462c88cea2a8f11a6e6"
+"@shopify/slate-config@^1.0.0-beta.1":
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@shopify/slate-config/-/slate-config-1.0.0-beta.1.tgz#2cf6c4600ecb9912b2966fff352184ae36e50973"
 
-"@shopify/slate-cssvar-loader@^1.0.0-alpha.29":
-  version "1.0.0-alpha.29"
-  resolved "https://registry.yarnpkg.com/@shopify/slate-cssvar-loader/-/slate-cssvar-loader-1.0.0-alpha.29.tgz#fdde9b9d856c62807b0514938037e91c24a0aa80"
+"@shopify/slate-cssvar-loader@^1.0.0-beta.1":
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@shopify/slate-cssvar-loader/-/slate-cssvar-loader-1.0.0-beta.1.tgz#85f1fd88f34a3de1ed9810937cdd710d4dd095c7"
   dependencies:
-    "@shopify/slate-config" "^1.0.0-alpha.29"
+    "@shopify/slate-config" "^1.0.0-beta.1"
     loader-utils "^1.1.0"
 
-"@shopify/slate-env@^1.0.0-alpha.29":
-  version "1.0.0-alpha.29"
-  resolved "https://registry.yarnpkg.com/@shopify/slate-env/-/slate-env-1.0.0-alpha.29.tgz#2aa09f408537ed210974563955d9702acb9d701f"
+"@shopify/slate-env@^1.0.0-beta.1":
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@shopify/slate-env/-/slate-env-1.0.0-beta.1.tgz#881a74a24232ac7b94a710e27b68af6a9f4d0063"
   dependencies:
-    "@shopify/slate-config" "^1.0.0-alpha.29"
+    "@shopify/slate-config" "^1.0.0-beta.1"
     dotenv "^4.0.0"
 
-"@shopify/slate-error@^1.0.0-alpha.29":
-  version "1.0.0-alpha.29"
-  resolved "https://registry.yarnpkg.com/@shopify/slate-error/-/slate-error-1.0.0-alpha.29.tgz#1a9aa5061c953465a13c6869a7b25a724075614f"
+"@shopify/slate-error@^1.0.0-beta.1":
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@shopify/slate-error/-/slate-error-1.0.0-beta.1.tgz#8d902f2953fa84bbdf1e541823dd2b54c4d4ee15"
 
-"@shopify/slate-liquid-asset-loader@^1.0.0-alpha.29":
-  version "1.0.0-alpha.29"
-  resolved "https://registry.yarnpkg.com/@shopify/slate-liquid-asset-loader/-/slate-liquid-asset-loader-1.0.0-alpha.29.tgz#7c1fab529cf22d79f3cd603839ab99d5eae5e832"
+"@shopify/slate-liquid-asset-loader@^1.0.0-beta.1":
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@shopify/slate-liquid-asset-loader/-/slate-liquid-asset-loader-1.0.0-beta.1.tgz#f0599880c83731a1603496ec92fe17a9bd8fcca8"
   dependencies:
     escape-string-regexp "^1.0.5"
     loader-utils "^1.1.0"
 
-"@shopify/slate-rc@^1.0.0-alpha.29":
-  version "1.0.0-alpha.29"
-  resolved "https://registry.yarnpkg.com/@shopify/slate-rc/-/slate-rc-1.0.0-alpha.29.tgz#f4529e9efff987f96f370692e15bb69dab7d9f7d"
+"@shopify/slate-rc@^1.0.0-beta.1":
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@shopify/slate-rc/-/slate-rc-1.0.0-beta.1.tgz#f616c10cad364ec3dc0c6ec4ed67e555a524716a"
   dependencies:
-    "@shopify/slate-config" "^1.0.0-alpha.29"
-    "@shopify/slate-error" "^1.0.0-alpha.29"
+    "@shopify/slate-config" "^1.0.0-beta.1"
+    "@shopify/slate-error" "^1.0.0-beta.1"
     fs-extra "^5.0.0"
     mock-fs "^4.4.2"
     semver "^5.5.0"
     uuid "^3.2.1"
 
-"@shopify/slate-sync@^1.0.0-alpha.29":
-  version "1.0.0-alpha.29"
-  resolved "https://registry.yarnpkg.com/@shopify/slate-sync/-/slate-sync-1.0.0-alpha.29.tgz#a3fe8780a794a51f3044137abab1c28cf6397923"
+"@shopify/slate-sync@^1.0.0-beta.1":
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@shopify/slate-sync/-/slate-sync-1.0.0-beta.1.tgz#08b743b4a4fd564d0a6558c1f8c495ed7190863e"
   dependencies:
-    "@shopify/slate-analytics" "^1.0.0-alpha.29"
-    "@shopify/slate-config" "^1.0.0-alpha.29"
-    "@shopify/slate-env" "^1.0.0-alpha.29"
+    "@shopify/slate-analytics" "^1.0.0-beta.1"
+    "@shopify/slate-config" "^1.0.0-beta.1"
+    "@shopify/slate-env" "^1.0.0-beta.1"
     "@shopify/themekit" "0.6.12"
     array-flatten "^2.1.1"
     chalk "2.3.2"
@@ -254,22 +254,22 @@
     jest "22.4.2"
     react-dev-utils "0.5.2"
 
-"@shopify/slate-tag-webpack-plugin@^1.0.0-alpha.29":
-  version "1.0.0-alpha.29"
-  resolved "https://registry.yarnpkg.com/@shopify/slate-tag-webpack-plugin/-/slate-tag-webpack-plugin-1.0.0-alpha.29.tgz#04d2e31fa5050b89b408d3dd9c7df02f00ec11b9"
+"@shopify/slate-tag-webpack-plugin@^1.0.0-beta.1":
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@shopify/slate-tag-webpack-plugin/-/slate-tag-webpack-plugin-1.0.0-beta.1.tgz#36e52386c1a5c3a215dc9bb8fc2646e768df3f78"
 
-"@shopify/slate-tools@>=1.0.0-alpha.29":
-  version "1.0.0-alpha.29"
-  resolved "https://registry.yarnpkg.com/@shopify/slate-tools/-/slate-tools-1.0.0-alpha.29.tgz#2298bb6a9ddbacb1e3c4f275215205c71583ab45"
+"@shopify/slate-tools@>=1.0.0-beta.1":
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@shopify/slate-tools/-/slate-tools-1.0.0-beta.1.tgz#630dce940e96fca300830cc95c15e6caaa66382d"
   dependencies:
-    "@shopify/html-webpack-liquid-asset-tags-plugin" "^1.0.0-alpha.29"
-    "@shopify/slate-analytics" "^1.0.0-alpha.29"
-    "@shopify/slate-config" "^1.0.0-alpha.29"
-    "@shopify/slate-cssvar-loader" "^1.0.0-alpha.29"
-    "@shopify/slate-env" "^1.0.0-alpha.29"
-    "@shopify/slate-liquid-asset-loader" "^1.0.0-alpha.29"
-    "@shopify/slate-sync" "^1.0.0-alpha.29"
-    "@shopify/slate-tag-webpack-plugin" "^1.0.0-alpha.29"
+    "@shopify/html-webpack-liquid-asset-tags-plugin" "^1.0.0-beta.1"
+    "@shopify/slate-analytics" "^1.0.0-beta.1"
+    "@shopify/slate-config" "^1.0.0-beta.1"
+    "@shopify/slate-cssvar-loader" "^1.0.0-beta.1"
+    "@shopify/slate-env" "^1.0.0-beta.1"
+    "@shopify/slate-liquid-asset-loader" "^1.0.0-beta.1"
+    "@shopify/slate-sync" "^1.0.0-beta.1"
+    "@shopify/slate-tag-webpack-plugin" "^1.0.0-beta.1"
     "@shopify/theme-lint" "^2.0.0"
     "@shopify/themekit" "0.6.12"
     archiver "^2.1.0"
@@ -279,7 +279,7 @@
     babel-loader "7.1.4"
     chalk "2.3.2"
     clean-webpack-plugin "0.1.19"
-    concat-style-loader "^1.0.0-alpha.29"
+    concat-style-loader "^1.0.0-beta.1"
     console-control-strings "^1.1.0"
     copy-webpack-plugin "^4.2.3"
     cors "^2.8.4"
@@ -2380,9 +2380,9 @@ concat-stream@^1.4.6, concat-stream@^1.4.7, concat-stream@^1.5.0, concat-stream@
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-concat-style-loader@^1.0.0-alpha.29:
-  version "1.0.0-alpha.29"
-  resolved "https://registry.yarnpkg.com/concat-style-loader/-/concat-style-loader-1.0.0-alpha.29.tgz#ec2050b89d4afba4012d4df99271eef2fef355a9"
+concat-style-loader@^1.0.0-beta.1:
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/concat-style-loader/-/concat-style-loader-1.0.0-beta.1.tgz#69b4180a3f08571dea102fce02dda018a9ea81ee"
   dependencies:
     loader-utils "^1.1.0"
 


### PR DESCRIPTION
While working on Debut's accessibility issues, I want to apply the same improvements on Starter Theme. This PR focuses on blog post :

- Removed the second <a> link in the article so we can avoid duplicating links
- Added `aria label` for "Read more"
- Used `<ul>` and `<li>` instead of `<div>` so the user can navigate easier with a hierarchy type of list.
- Added `<ul>` and `<li>` for the list of tags
- Replaced `<h2>` to `<h3>` in the article's title

[Demo store](https://064qpumzdmtzpd80-662601789.shopifypreview.com/)
[Theme editor](https://tauclothes.myshopify.com/admin/themes/15250030653/editor)

References to Debut's accessibility PR improvements
https://github.com/Shopify/debut/pull/390
https://github.com/Shopify/debut/pull/393