### PR TITLE
Add CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:8.11.1
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
A CircleCI config that acts a starting point for continuous integration. Currently, the only thing we're doing is installing dependencies, downloading ThemeKit, and linting our project.