### PR TITLE
Replace microdata with JSON-LD

### DIFF
--- a/src/layout/password.liquid
+++ b/src/layout/password.liquid
@@ -25,7 +25,7 @@
 
 <body class="template-password">
   <header role="banner">
-    <h1 itemscope itemtype="http://schema.org/Organization">
+    <h1>
       <div class="site-logo">
         {{ shop.name }}
       </div>
@@ -63,3 +63,26 @@
   </div>
 </body>
 </html>
+
+<script type="application/ld+json">
+  {
+  "@context": "http://schema.org",
+  "@type": "Organization",
+  "name": "{{ shop.name }}",
+  {% if section.settings.logo %}
+    {% assign image_size = section.settings.logo.width | append:'x' %}
+    "logo": "https:{{ section.settings.logo | img_url: image_size }}",
+  {% endif %}
+  "sameAs": [
+    "{{ settings.social_twitter_link }}",
+    "{{ settings.social_facebook_link }}",
+    "{{ settings.social_pinterest_link }}",
+    "{{ settings.social_instagram_link }}",
+    "{{ settings.social_tumblr_link }}",
+    "{{ settings.social_snapchat_link }}",
+    "{{ settings.social_youtube_link }}",
+    "{{ settings.social_vimeo_link }}"
+  ],
+  "url": "{{ shop.url }}{{ page.url }}"
+}
+</script>

--- a/src/layout/password.liquid
+++ b/src/layout/password.liquid
@@ -26,9 +26,7 @@
 <body class="template-password">
   <header role="banner">
     <h1>
-      <div class="site-logo">
-        {{ shop.name }}
-      </div>
+      {{ shop.name }}
     </h1>
   </header>
 

--- a/src/sections/featured-product.liquid
+++ b/src/sections/featured-product.liquid
@@ -7,11 +7,7 @@
   {%- assign onboarding_title = 'homepage.onboarding.product_title' | t -%}
 {% endif %}
 
-<div data-section-id="{{ section.id }}" data-section-type="product" itemscope itemtype="http://schema.org/Product">
-  <meta itemprop="name" content="{{ product.title }}">
-  <meta itemprop="url" content="{{ shop.url }}{{ product.url }}">
-  <meta itemprop="image" content="{{ featured_image | img_url: '800x' }}">
-  <meta itemprop="description" content="{{ product.description | strip_html | escape }}">
+<div data-section-id="{{ section.id }}" data-section-type="product">
 
   {% if featured_image.src != blank %}
     {% include 'responsive-image' with
@@ -38,10 +34,7 @@
     <p>{{ product.vendor }}</p>
   {% endif %}
 
-  <div itemprop="offers" itemscope itemtype="http://schema.org/Offer">
-    <meta itemprop="priceCurrency" content="{{ shop.currency }}">
-    <meta itemprop="price" content="{{ product.price | divided_by: 100.00 }}">
-    <link itemprop="availability" href="http://schema.org/{% if product.available %}InStock{% else %}OutOfStock{% endif %}">
+  <div>
 
     <form action="/cart/add" method="post" enctype="multipart/form-data">
       {% unless product.has_only_default_variant %}
@@ -152,3 +145,63 @@
     ]
   }
 {% endschema %}
+
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org/",
+  "@type": "Product",
+  "name": "{{ product.title | escape }}",
+  "url": "{{ shop.url }}{{ product.url }}",
+  {% if product.featured_image %}
+    {% assign image_size = product.featured_image.width | append: 'x' %}
+    "image": [
+      "https:{{ product.featured_image.src | img_url: image_size }}"
+    ],
+  {% endif %}
+  "description": "{{ product.description | strip_html | escape }}",
+  {% if current_variant.sku != blank %}
+    "sku": "{{ current_variant.sku }}",
+  {% endif %}
+  "brand": {
+    "@type": "Thing",
+    "name": "{{ product.vendor | escape }}"
+  },
+  {% if product.variants %}
+    "offers": [
+      {% for variant in product.variants %}
+        {
+          "@type" : "Offer",
+          "availability" : "http://schema.org/{% if product.available %}InStock{% else %}OutOfStock{% endif %}",
+          "price" : "{{ variant.price | divided_by: 100.00 }}",
+          "priceCurrency" : "{{ shop.currency }}",
+          "url" : "{{ shop.url }}{{ variant.url }}",
+          "itemOffered" :
+          {
+              "@type" : "Product",
+              {% if variant.image %}
+                {% assign variant_image_size = variant.image.width | append: 'x' %}
+                "image": "http:{{ variant.image.src | img_url: variant_image_size }}",
+              {% endif %}
+              {% if variant.title != blank %}
+                "name" : "{{ variant.title | escape }}",
+              {% endif %}
+              {% if variant.sku != blank %}
+                "sku": "{{ variant.sku }}",
+              {% endif %}
+              {% if variant.weight != blank %}
+                "weight": {
+                  "@type": "QuantitativeValue",
+                  {% if variant.weight_unit != blank %}
+                    "unitCode": "{{ variant.weight_unit }}",
+                  {% endif %}
+                  "value": "{{ variant.weight | weight_with_unit: variant.weight_unit }}"
+                },
+              {% endif %}
+              "url": "{{ shop.url }}{{ variant.url }}"
+          }
+        }{% unless forloop.last %},{% endunless %}
+      {% endfor %}
+    ]
+  {% endif %}
+}
+</script>

--- a/src/sections/header.liquid
+++ b/src/sections/header.liquid
@@ -27,17 +27,16 @@
 
   <header role="banner">
     {% if template.name == 'index' %}
-      <h1 itemscope itemtype="http://schema.org/Organization">
+      <h1>
     {% else %}
-      <div class="h1" itemscope itemtype="http://schema.org/Organization">
+      <div class="h1">
     {% endif %}
-        <a href="/" itemprop="url"{% if section.settings.logo != blank %} class="logo-image"{% endif %}>
+        <a href="/" class="logo-image"{% endif %}>
           {% if section.settings.logo != blank %}
             {% capture image_size %}{{ section.settings.logo_max_width }}x{% endcapture %}
             <img src="{{ section.settings.logo | img_url: image_size }}"
                 srcset="{{ section.settings.logo | img_url: image_size }} 1x, {{ section.settings.logo | img_url: image_size, scale: 2 }} 2x"
-                alt="{{ section.settings.logo.alt | default: shop.name }}"
-                itemprop="logo">
+                alt="{{ section.settings.logo.alt | default: shop.name }}">
           {% else %}
             {{ shop.name }}
           {% endif %}
@@ -197,3 +196,42 @@
     ]
   }
 {% endschema %}
+
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "Organization",
+  "name": "{{ shop.name }}",
+  {% if section.settings.logo %}
+    {% assign image_size = section.settings.logo.width | append:'x' %}
+    "logo": "https:{{ section.settings.logo | img_url: image_size }}",
+  {% endif %}
+  "sameAs": [
+    "{{ settings.social_twitter_link }}",
+    "{{ settings.social_facebook_link }}",
+    "{{ settings.social_pinterest_link }}",
+    "{{ settings.social_instagram_link }}",
+    "{{ settings.social_tumblr_link }}",
+    "{{ settings.social_snapchat_link }}",
+    "{{ settings.social_youtube_link }}",
+    "{{ settings.social_vimeo_link }}"
+  ],
+  "url": "{{ shop.url }}{{ page.url }}"
+}
+</script>
+
+{% if template.name == 'index' %}
+  <script type="application/ld+json">
+    {
+      "@context": "http://schema.org",
+      "@type": "WebSite",
+      "name": "{{ shop.name }}",
+      "potentialAction": {
+        "@type": "SearchAction",
+        "target": "{{ shop.url }}/search?q={search_term_string}",
+        "query-input": "required name=search_term_string"
+      },
+      "url": "{{ shop.url }}{{ page.url }}"
+    }
+  </script>
+{% endif %}

--- a/src/sections/product.liquid
+++ b/src/sections/product.liquid
@@ -1,13 +1,7 @@
-<div data-section-id="{{ section.id }}" data-section-type="product" data-enable-history-state="true" itemscope itemtype="http://schema.org/Product">
+<div data-section-id="{{ section.id }}" data-section-type="product" data-enable-history-state="true">
 
   {%- assign current_variant = product.selected_or_first_available_variant -%}
   {%- assign featured_image = current_variant.featured_image | default: product.featured_image -%}
-
-  <meta itemprop="name" content="{{ product.title }}{% unless product.has_only_default_variant %} - {{ current_variant.title }}{% endunless %}">
-  <meta itemprop="url" content="{{ shop.url }}{{ current_variant.url }}">
-  <meta itemprop="brand" content="{{ product.vendor }}">
-  <meta itemprop="image" content="{{ featured_image | img_url: '600x600' }}">
-  <meta itemprop="description" content="{{ product.description | strip_html | escape }}">
 
   {% if featured_image != blank %}
     {% include 'responsive-image' with
@@ -32,80 +26,74 @@
   <h1>{{ product.title }}</h1>
   <p>{{ product.vendor }}</p>
 
-  <div itemprop="offers" itemscope itemtype="http://schema.org/Offer">
-    <meta itemprop="priceCurrency" content="{{ shop.currency }}">
-    <meta itemprop="price" content="{{ current_variant.price | divided_by: 100.00 }}">
-    <link itemprop="availability" href="http://schema.org/{% if current_variant.available %}InStock{% else %}OutOfStock{% endif %}">
 
-    <form action="/cart/add" method="post" enctype="multipart/form-data">
-      {% unless product.has_only_default_variant %}
-        {% for option in product.options_with_values %}
-          <div class="selector-wrapper js">
-            <label for="SingleOptionSelector-{{ forloop.index0 }}">
-              {{ option.name }}
-            </label>
+  <form action="/cart/add" method="post" enctype="multipart/form-data">
+    {% unless product.has_only_default_variant %}
+      {% for option in product.options_with_values %}
+        <div class="selector-wrapper js">
+          <label for="SingleOptionSelector-{{ forloop.index0 }}">
+            {{ option.name }}
+          </label>
 
-            <select
-              id="SingleOptionSelector-{{ forloop.index0 }}"
-              data-single-option-selector
-              data-index="option{{ option.position }}">
-              {% for value in option.values %}
-                <option
-                  value="{{ value | escape }}"
-                  {% if option.selected_value == value %}selected="selected"{% endif %}>
-                    {{ value }}
-                </option>
-              {% endfor %}
-            </select>
-          </div>
-        {% endfor %}
-      {% endunless %}
+          <select
+            id="SingleOptionSelector-{{ forloop.index0 }}"
+            data-single-option-selector
+            data-index="option{{ option.position }}">
+            {% for value in option.values %}
+              <option
+                value="{{ value | escape }}"
+                {% if option.selected_value == value %}selected="selected"{% endif %}>
+                  {{ value }}
+              </option>
+            {% endfor %}
+          </select>
+        </div>
+      {% endfor %}
+    {% endunless %}
 
-      <select name="id" class="no-js" data-product-select>
-        {% for variant in product.variants %}
-          <option
-            {% if variant == current_variant %}selected="selected"{% endif %}
-            {% unless variant.available %}disabled="disabled"{% endunless %}
-            value="{{ variant.id }}">
-              {{ variant.title }}
-          </option>
-        {% endfor %}
-      </select>
+    <select name="id" class="no-js" data-product-select>
+      {% for variant in product.variants %}
+        <option
+          {% if variant == current_variant %}selected="selected"{% endif %}
+          {% unless variant.available %}disabled="disabled"{% endunless %}
+          value="{{ variant.id }}">
+            {{ variant.title }}
+        </option>
+      {% endfor %}
+    </select>
 
-      <label for="Quantity">{{ 'products.product.quantity' | t }}</label>
-      <input type="number" id="Quantity" name="quantity" value="1" min="1">
+    <label for="Quantity">{{ 'products.product.quantity' | t }}</label>
+    <input type="number" id="Quantity" name="quantity" value="1" min="1">
 
-      <div data-price-wrapper>
-        <span data-product-price>
-          {{ current_variant.price | money }}
+    <div data-price-wrapper>
+      <span data-product-price>
+        {{ current_variant.price | money }}
+      </span>
+
+      {% if product.compare_at_price_max > product.price %}
+        <span class="visually-hidden" data-compare-text>{{ 'products.product.regular_price' | t }}</span>
+        <s data-compare-price>
+          {% if current_variant.compare_at_price > current_variant.price %}
+            {{ current_variant.compare_at_price | money }}
+          {% endif %}
+        </s>
+      {% endif %}
+    </div>
+
+    <button
+      type="submit"
+      name="add"
+      data-add-to-cart
+      {% unless current_variant.available %}disabled="disabled"{% endunless %}>
+        <span data-add-to-cart-text>
+          {% if current_variant.available %}
+            {{ 'products.product.add_to_cart' | t }}
+          {% else %}
+            {{ 'products.product.sold_out' | t }}
+          {% endif %}
         </span>
-
-        {% if product.compare_at_price_max > product.price %}
-          <span class="visually-hidden" data-compare-text>{{ 'products.product.regular_price' | t }}</span>
-          <s data-compare-price>
-            {% if current_variant.compare_at_price > current_variant.price %}
-              {{ current_variant.compare_at_price | money }}
-            {% endif %}
-          </s>
-        {% endif %}
-      </div>
-
-      <button
-        type="submit"
-        name="add"
-        data-add-to-cart
-        {% unless current_variant.available %}disabled="disabled"{% endunless %}>
-          <span data-add-to-cart-text>
-            {% if current_variant.available %}
-              {{ 'products.product.add_to_cart' | t }}
-            {% else %}
-              {{ 'products.product.sold_out' | t }}
-            {% endif %}
-          </span>
-      </button>
-    </form>
-
-  </div>
+    </button>
+  </form>
 
   <div class="rte">
     {{ product.description }}

--- a/src/templates/article.liquid
+++ b/src/templates/article.liquid
@@ -204,6 +204,14 @@
         "url": "https:{{ settings.share_image | img_url: image_size }}",
         "width": "{{ settings.share_image.width }}"
       },
+    {% elsif article.image %}
+      {% assign image_size = article.image.width | append: 'x' %}
+      "logo": {
+        "@type": "ImageObject",
+        "height": "{{ article.image.height }}",
+        "url": "https:{{ article.image | img_url: image_size }}",
+        "width": "{{ article.image.width }}"
+      },
     {% endif %}
     "name": "{{ shop.name }}"
   }

--- a/src/templates/article.liquid
+++ b/src/templates/article.liquid
@@ -32,7 +32,7 @@
   {%- endunless -%}
 {%- endif -%}
 
-<article role="article" itemscope itemtype="http://schema.org/Article">
+<article role="article">
 
   {% if article.image %}
     <div class="hero-banner hero-banner--article lazyload" data-bgset="{% include 'responsive-bg-image', image: article.image %}"></div>
@@ -49,7 +49,7 @@
     <p>{{ 'blogs.article.author_on_date_html' | t: author: article.author, date: date }}</p>
   </header>
 
-  <div class="rte" itemprop="articleBody">
+  <div class="rte">
     {{ article.content }}
   </div>
 
@@ -168,3 +168,44 @@
   {% endif %}
 
 </article>
+
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "Article",
+  "articleBody": "{{ article.content | strip_html }}",
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "{{ shop.url }}{{ page.url }}"
+  },
+  "headline": "{{ article.title }}",
+  {% if article.excerpt != blank %}
+    "description": "{{ article.excerpt | strip_html }}",
+  {% endif %}
+  {% if article.image %}
+    {% assign image_size = article.image.width | append: 'x' %}
+    "image": [
+      "https:{{ article | img_url: image_size }}"
+    ],
+  {% endif %}
+  "datePublished": "{{ article.published_at | date: '%Y-%m-%dT%H:%M:%SZ' }}",
+  "dateCreated": "{{ article.created_at | date: '%Y-%m-%dT%H:%M:%SZ' }}",
+  "author": {
+    "@type": "Person",
+    "name": "{{ article.author }}"
+  },
+  "publisher": {
+    "@type": "Organization",
+    {% if settings.share_image %}
+      {% assign image_size = settings.share_image.width | append: 'x' %}
+      "logo": {
+        "@type": "ImageObject",
+        "height": "{{ settings.share_image.height }}",
+        "url": "https:{{ settings.share_image | img_url: image_size }}",
+        "width": "{{ settings.share_image.width }}"
+      },
+    {% endif %}
+    "name": "{{ shop.name }}"
+  }
+}
+</script>

--- a/src/templates/gift_card.liquid
+++ b/src/templates/gift_card.liquid
@@ -7,8 +7,8 @@
 {% layout 'gift_card' %}
 
 <header role="banner">
-  <div itemscope itemtype="http://schema.org/Organization">
-    <a href="{{ shop.url }}" itemprop="url" class="site-logo">
+  <div>
+    <a href="{{ shop.url }}">
       {{ shop.name }}
     </a>
   </div>

--- a/src/templates/gift_card.liquid
+++ b/src/templates/gift_card.liquid
@@ -7,11 +7,9 @@
 {% layout 'gift_card' %}
 
 <header role="banner">
-  <div>
     <a href="{{ shop.url }}">
       {{ shop.name }}
     </a>
-  </div>
   <div>{{ shop.url | escape }}</div>
 </header>
 

--- a/src/templates/product.liquid
+++ b/src/templates/product.liquid
@@ -1,1 +1,61 @@
 {% section 'product' %}
+
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org/",
+  "@type": "Product",
+  "name": "{{ product.title | escape }}",
+  "url": "{{ shop.url }}{{ product.url }}",
+  {% if product.featured_image %}
+    {% assign image_size = product.featured_image.width | append: 'x' %}
+    "image": [
+      "https:{{ product.featured_image.src | img_url: image_size }}"
+    ],
+  {% endif %}
+  "description": "{{ product.description | strip_html | escape }}",
+  {% if current_variant.sku != blank %}
+    "sku": "{{ current_variant.sku }}",
+  {% endif %}
+  "brand": {
+    "@type": "Thing",
+    "name": "{{ product.vendor | escape }}"
+  },
+  {% if product.variants %}
+    "offers": [
+      {% for variant in product.variants %}
+        {
+          "@type" : "Offer",
+          "availability" : "http://schema.org/{% if product.available %}InStock{% else %}OutOfStock{% endif %}",
+          "price" : "{{ variant.price | divided_by: 100.00 }}",
+          "priceCurrency" : "{{ shop.currency }}",
+          "url" : "{{ shop.url }}{{ variant.url }}",
+          "itemOffered" :
+          {
+              "@type" : "Product",
+              {% if variant.image %}
+                {% assign variant_image_size = variant.image.width | append: 'x' %}
+                "image": "http:{{ variant.image.src | img_url: variant_image_size }}",
+              {% endif %}
+              {% if variant.title != blank %}
+                "name" : "{{ variant.title | escape }}",
+              {% endif %}
+              {% if variant.sku != blank %}
+                "sku": "{{ variant.sku }}",
+              {% endif %}
+              {% if variant.weight != blank %}
+                "weight": {
+                  "@type": "QuantitativeValue",
+                  {% if variant.weight_unit != blank %}
+                    "unitCode": "{{ variant.weight_unit }}",
+                  {% endif %}
+                  "value": "{{ variant.weight | weight_with_unit: variant.weight_unit }}"
+                },
+              {% endif %}
+              "url": "{{ shop.url }}{{ variant.url }}"
+          }
+        }{% unless forloop.last %},{% endunless %}
+      {% endfor %}
+    ]
+  {% endif %}
+}
+</script>

--- a/src/templates/search.liquid
+++ b/src/templates/search.liquid
@@ -47,16 +47,16 @@
                     {{ 'products.product.on_sale_from_html' | t: price: sale_price }}
                   {% else %}
                     {{ 'products.product.on_sale' | t }}
-                    <span itemprop="price">{{ item.price | money }}</span>
+                    <span>{{ item.price | money }}</span>
                   {% endif %}
                   <span class="visually-hidden">{{ 'products.product.regular_price' | t }}</span>
                   <s>{{ item.compare_at_price | money }}</s>
                 {% else %}
                   {% if item.price_varies %}
                     {% assign price = item.price | money %}
-                    <span itemprop="price">{{ 'products.product.from_text_html' | t: price: price }}</span>
+                    <span>{{ 'products.product.from_text_html' | t: price: price }}</span>
                   {% else %}
-                    <span itemprop="price">{{ item.price | money }}</span>
+                    <span>{{ item.price | money }}</span>
                   {% endif %}
                 {% endif %}
                 {% unless item.available %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -182,16 +182,16 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@shopify/html-webpack-liquid-asset-tags-plugin@^1.0.0-alpha.29":
-  version "1.0.0-alpha.29"
-  resolved "https://registry.yarnpkg.com/@shopify/html-webpack-liquid-asset-tags-plugin/-/html-webpack-liquid-asset-tags-plugin-1.0.0-alpha.29.tgz#b6d92e072646a7b294588d4940eaf19a879f4938"
+"@shopify/html-webpack-liquid-asset-tags-plugin@^1.0.0-beta.1":
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@shopify/html-webpack-liquid-asset-tags-plugin/-/html-webpack-liquid-asset-tags-plugin-1.0.0-beta.1.tgz#d077b589a4d0cd537f70dbee81b202d5b44f1d14"
 
-"@shopify/slate-analytics@^1.0.0-alpha.29":
-  version "1.0.0-alpha.29"
-  resolved "https://registry.yarnpkg.com/@shopify/slate-analytics/-/slate-analytics-1.0.0-alpha.29.tgz#dd7813cafd32d85399a14cdfc0262df14d80de3e"
+"@shopify/slate-analytics@^1.0.0-beta.1":
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@shopify/slate-analytics/-/slate-analytics-1.0.0-beta.1.tgz#7027bf59589b669b96f29195c41ba86ade02fdb4"
   dependencies:
-    "@shopify/slate-error" "^1.0.0-alpha.29"
-    "@shopify/slate-rc" "^1.0.0-alpha.29"
+    "@shopify/slate-error" "^1.0.0-beta.1"
+    "@shopify/slate-rc" "^1.0.0-beta.1"
     axios "^0.18.0"
     chalk "^2.3.0"
     inquirer "^5.0.1"
@@ -199,53 +199,53 @@
     uuid "^3.2.1"
     word-wrap "^1.2.3"
 
-"@shopify/slate-config@^1.0.0-alpha.29":
-  version "1.0.0-alpha.29"
-  resolved "https://registry.yarnpkg.com/@shopify/slate-config/-/slate-config-1.0.0-alpha.29.tgz#c6772f7c99998966aeeb1462c88cea2a8f11a6e6"
+"@shopify/slate-config@^1.0.0-beta.1":
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@shopify/slate-config/-/slate-config-1.0.0-beta.1.tgz#2cf6c4600ecb9912b2966fff352184ae36e50973"
 
-"@shopify/slate-cssvar-loader@^1.0.0-alpha.29":
-  version "1.0.0-alpha.29"
-  resolved "https://registry.yarnpkg.com/@shopify/slate-cssvar-loader/-/slate-cssvar-loader-1.0.0-alpha.29.tgz#fdde9b9d856c62807b0514938037e91c24a0aa80"
+"@shopify/slate-cssvar-loader@^1.0.0-beta.1":
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@shopify/slate-cssvar-loader/-/slate-cssvar-loader-1.0.0-beta.1.tgz#85f1fd88f34a3de1ed9810937cdd710d4dd095c7"
   dependencies:
-    "@shopify/slate-config" "^1.0.0-alpha.29"
+    "@shopify/slate-config" "^1.0.0-beta.1"
     loader-utils "^1.1.0"
 
-"@shopify/slate-env@^1.0.0-alpha.29":
-  version "1.0.0-alpha.29"
-  resolved "https://registry.yarnpkg.com/@shopify/slate-env/-/slate-env-1.0.0-alpha.29.tgz#2aa09f408537ed210974563955d9702acb9d701f"
+"@shopify/slate-env@^1.0.0-beta.1":
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@shopify/slate-env/-/slate-env-1.0.0-beta.1.tgz#881a74a24232ac7b94a710e27b68af6a9f4d0063"
   dependencies:
-    "@shopify/slate-config" "^1.0.0-alpha.29"
+    "@shopify/slate-config" "^1.0.0-beta.1"
     dotenv "^4.0.0"
 
-"@shopify/slate-error@^1.0.0-alpha.29":
-  version "1.0.0-alpha.29"
-  resolved "https://registry.yarnpkg.com/@shopify/slate-error/-/slate-error-1.0.0-alpha.29.tgz#1a9aa5061c953465a13c6869a7b25a724075614f"
+"@shopify/slate-error@^1.0.0-beta.1":
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@shopify/slate-error/-/slate-error-1.0.0-beta.1.tgz#8d902f2953fa84bbdf1e541823dd2b54c4d4ee15"
 
-"@shopify/slate-liquid-asset-loader@^1.0.0-alpha.29":
-  version "1.0.0-alpha.29"
-  resolved "https://registry.yarnpkg.com/@shopify/slate-liquid-asset-loader/-/slate-liquid-asset-loader-1.0.0-alpha.29.tgz#7c1fab529cf22d79f3cd603839ab99d5eae5e832"
+"@shopify/slate-liquid-asset-loader@^1.0.0-beta.1":
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@shopify/slate-liquid-asset-loader/-/slate-liquid-asset-loader-1.0.0-beta.1.tgz#f0599880c83731a1603496ec92fe17a9bd8fcca8"
   dependencies:
     escape-string-regexp "^1.0.5"
     loader-utils "^1.1.0"
 
-"@shopify/slate-rc@^1.0.0-alpha.29":
-  version "1.0.0-alpha.29"
-  resolved "https://registry.yarnpkg.com/@shopify/slate-rc/-/slate-rc-1.0.0-alpha.29.tgz#f4529e9efff987f96f370692e15bb69dab7d9f7d"
+"@shopify/slate-rc@^1.0.0-beta.1":
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@shopify/slate-rc/-/slate-rc-1.0.0-beta.1.tgz#f616c10cad364ec3dc0c6ec4ed67e555a524716a"
   dependencies:
-    "@shopify/slate-config" "^1.0.0-alpha.29"
-    "@shopify/slate-error" "^1.0.0-alpha.29"
+    "@shopify/slate-config" "^1.0.0-beta.1"
+    "@shopify/slate-error" "^1.0.0-beta.1"
     fs-extra "^5.0.0"
     mock-fs "^4.4.2"
     semver "^5.5.0"
     uuid "^3.2.1"
 
-"@shopify/slate-sync@^1.0.0-alpha.29":
-  version "1.0.0-alpha.29"
-  resolved "https://registry.yarnpkg.com/@shopify/slate-sync/-/slate-sync-1.0.0-alpha.29.tgz#a3fe8780a794a51f3044137abab1c28cf6397923"
+"@shopify/slate-sync@^1.0.0-beta.1":
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@shopify/slate-sync/-/slate-sync-1.0.0-beta.1.tgz#08b743b4a4fd564d0a6558c1f8c495ed7190863e"
   dependencies:
-    "@shopify/slate-analytics" "^1.0.0-alpha.29"
-    "@shopify/slate-config" "^1.0.0-alpha.29"
-    "@shopify/slate-env" "^1.0.0-alpha.29"
+    "@shopify/slate-analytics" "^1.0.0-beta.1"
+    "@shopify/slate-config" "^1.0.0-beta.1"
+    "@shopify/slate-env" "^1.0.0-beta.1"
     "@shopify/themekit" "0.6.12"
     array-flatten "^2.1.1"
     chalk "2.3.2"
@@ -254,22 +254,22 @@
     jest "22.4.2"
     react-dev-utils "0.5.2"
 
-"@shopify/slate-tag-webpack-plugin@^1.0.0-alpha.29":
-  version "1.0.0-alpha.29"
-  resolved "https://registry.yarnpkg.com/@shopify/slate-tag-webpack-plugin/-/slate-tag-webpack-plugin-1.0.0-alpha.29.tgz#04d2e31fa5050b89b408d3dd9c7df02f00ec11b9"
+"@shopify/slate-tag-webpack-plugin@^1.0.0-beta.1":
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@shopify/slate-tag-webpack-plugin/-/slate-tag-webpack-plugin-1.0.0-beta.1.tgz#36e52386c1a5c3a215dc9bb8fc2646e768df3f78"
 
-"@shopify/slate-tools@>=1.0.0-alpha.29":
-  version "1.0.0-alpha.29"
-  resolved "https://registry.yarnpkg.com/@shopify/slate-tools/-/slate-tools-1.0.0-alpha.29.tgz#2298bb6a9ddbacb1e3c4f275215205c71583ab45"
+"@shopify/slate-tools@>=1.0.0-beta.1":
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@shopify/slate-tools/-/slate-tools-1.0.0-beta.1.tgz#630dce940e96fca300830cc95c15e6caaa66382d"
   dependencies:
-    "@shopify/html-webpack-liquid-asset-tags-plugin" "^1.0.0-alpha.29"
-    "@shopify/slate-analytics" "^1.0.0-alpha.29"
-    "@shopify/slate-config" "^1.0.0-alpha.29"
-    "@shopify/slate-cssvar-loader" "^1.0.0-alpha.29"
-    "@shopify/slate-env" "^1.0.0-alpha.29"
-    "@shopify/slate-liquid-asset-loader" "^1.0.0-alpha.29"
-    "@shopify/slate-sync" "^1.0.0-alpha.29"
-    "@shopify/slate-tag-webpack-plugin" "^1.0.0-alpha.29"
+    "@shopify/html-webpack-liquid-asset-tags-plugin" "^1.0.0-beta.1"
+    "@shopify/slate-analytics" "^1.0.0-beta.1"
+    "@shopify/slate-config" "^1.0.0-beta.1"
+    "@shopify/slate-cssvar-loader" "^1.0.0-beta.1"
+    "@shopify/slate-env" "^1.0.0-beta.1"
+    "@shopify/slate-liquid-asset-loader" "^1.0.0-beta.1"
+    "@shopify/slate-sync" "^1.0.0-beta.1"
+    "@shopify/slate-tag-webpack-plugin" "^1.0.0-beta.1"
     "@shopify/theme-lint" "^2.0.0"
     "@shopify/themekit" "0.6.12"
     archiver "^2.1.0"
@@ -279,7 +279,7 @@
     babel-loader "7.1.4"
     chalk "2.3.2"
     clean-webpack-plugin "0.1.19"
-    concat-style-loader "^1.0.0-alpha.29"
+    concat-style-loader "^1.0.0-beta.1"
     console-control-strings "^1.1.0"
     copy-webpack-plugin "^4.2.3"
     cors "^2.8.4"
@@ -2380,9 +2380,9 @@ concat-stream@^1.4.6, concat-stream@^1.4.7, concat-stream@^1.5.0, concat-stream@
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-concat-style-loader@^1.0.0-alpha.29:
-  version "1.0.0-alpha.29"
-  resolved "https://registry.yarnpkg.com/concat-style-loader/-/concat-style-loader-1.0.0-alpha.29.tgz#ec2050b89d4afba4012d4df99271eef2fef355a9"
+concat-style-loader@^1.0.0-beta.1:
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/concat-style-loader/-/concat-style-loader-1.0.0-beta.1.tgz#69b4180a3f08571dea102fce02dda018a9ea81ee"
   dependencies:
     loader-utils "^1.1.0"
 


### PR DESCRIPTION
**[WIP]: Missing fix for edge case described [in my comment here](https://github.com/Shopify/debut/issues/409#issuecomment-389574727).**

Closes #52.

[Link to Tester Store](https://ericktester123.myshopify.com/?preview_theme_id=13093765235)

### What I did
I replaced all microdata properties with JSON-LD, using the [changes made to Debut](https://github.com/Shopify/debut/pull/184) as a reference.

I copied over the formats that Thomas had used onto the corresponding pages on Debut. I tested a couple pages (Password, Product, Home, Blog Article) using the [Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool) and things seemed to work (except for aforementioned edge case).

Furthermore, all mentions of [microdata properties](https://developer.mozilla.org/en-US/docs/Web/HTML/Microdata) (`itemprop`, `itemtype`, etc.) should have been wiped.

### Possible issues to review
* Need to verify if any of the JSON-LD scripts need additional filtering (e.g. `| escape`). I added a few escapes, but am not too familiar with the edge cases for many of these Liquid object properties.
* Need to check if any additional pages need JSON-LD scripts added to them (not sure if my first pass was complete).