### PR TITLE
feat: Add social sharing image to settings schema

### DIFF
--- a/src/config/settings_schema.json
+++ b/src/config/settings_schema.json
@@ -53,6 +53,16 @@
     "settings": [
       {
         "type": "header",
+        "content": "Social sharing image"
+      },
+      {
+        "type": "image_picker",
+        "id": "share_image",
+        "label": "Image",
+        "info": "Shown when sharing a link on social media. [Learn more](https://help.shopify.com/manual/using-themes/troubleshooting/showing-social-media-thumbnail-images/) about image thumbnails."
+      },
+      {
+        "type": "header",
         "content": "Social sharing options"
       },
       {

--- a/src/snippets/social-meta-tags.liquid
+++ b/src/snippets/social-meta-tags.liquid
@@ -2,6 +2,10 @@
 {%- assign og_url = canonical_url -%}
 {%- assign og_type = 'website' -%}
 {%- assign og_description = page_description | default: shop.description | default: shop.name -%}
+{% if settings.share_image %}
+  {%- capture og_image_tags -%}<meta property="og:image" content="http:{{ settings.share_image | img_url: '1200x1200' }}">{%- endcapture -%}
+  {%- capture og_image_secure_url_tags -%}<meta property="og:image:secure_url" content="https:{{ settings.share_image | img_url: '1200x1200' }}">{%- endcapture -%}
+{% endif %}
 
 {% comment %}
   Template specific overides


### PR DESCRIPTION
### What I'm trying to achieve

Starter Theme is currently missing the `{{ settings.share_image }}` property that I need to fill out the JSON-LD for #52, so I'm proposing to add it in with this PR.

### What I did

I added the `share_image` property into `settings_schema.json`, similar to the option available in other themes.

Also added the `og` tag code to populate the header with `og:image` tags with the `settings.share_image` URL.

[Link to tester store](https://ericktester123.myshopify.com?preview_theme_id=14574747763).

### Screenshots

![image](https://user-images.githubusercontent.com/16010076/40249876-6b40964a-5aa2-11e8-88e9-4dee99ee27bf.png)

![image](https://user-images.githubusercontent.com/16010076/40249902-8663eb0c-5aa2-11e8-8ef9-c3de25a71155.png)



