### PR TITLE
Remove bin script for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,10 @@
 language: node_js
 node_js:
   - "8.11.1"
-before_install:
-  - chmod +x bin/accept_slate_tools
 cache:
   yarn: true
   directories:
   - node_modules
 script:
-- bin/accept_slate_tools
 - yarn build
 - yarn lint

--- a/bin/accept_slate_tools
+++ b/bin/accept_slate_tools
@@ -1,1 +1,0 @@
-echo '{"uuid":"67ca765a-ed7e-4b89-b0c2-93a943ecd541","email":"starter.theme@shopify.com","tracking":true,"trackingVersion":1}' > ~/.slaterc


### PR DESCRIPTION
Removes the previously added `bin/accept_slate_tools` script we had for Travis CI and uses environment variables instead.