### PR TITLE
Ignore static assets folder from being formatted

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+src/assets/static/


### PR DESCRIPTION
Fixes Shopify/slate#596.

Adds an `.eslintignore` file to exclude the static assets folder from being formatted when running `yarn format`.