### PR TITLE
Updated social meta tags to use correct OG type for products and articles

### DIFF
--- a/src/snippets/social-meta-tags.liquid
+++ b/src/snippets/social-meta-tags.liquid
@@ -1,6 +1,13 @@
 {%- assign og_title = page_title -%}
 {%- assign og_url = canonical_url -%}
-{%- assign og_type = 'website' -%}
+{% case template.name %}
+  {% when 'article' %}
+    {%- assign og_type = 'article' -%}
+  {% when 'product' %}
+    {%- assign og_type = 'product' -%}
+  {% else %}
+    {%- assign og_type = 'website' -%}
+{% endcase %}
 {%- assign og_description = page_description | default: shop.description | default: shop.name -%}
 {% if settings.share_image %}
   {%- capture og_image_tags -%}<meta property="og:image" content="http:{{ settings.share_image | img_url: '1200x1200' }}">{%- endcapture -%}


### PR DESCRIPTION
Added switch statement to social meta tags so that OG type is set to Article or Product when applicable.

This means extra OG info already included like amount / currency is correctly pulled through. 

![screen shot 2018-05-31 at 3 39 53 pm](https://user-images.githubusercontent.com/1315304/40763654-eb313b3e-64e8-11e8-8131-49049c10489a.png)

https://developers.facebook.com/docs/reference/opengraph#object-type