### PR TITLE
Improved Open Graph images and product price

### DIFF
--- a/src/snippets/social-meta-tags.liquid
+++ b/src/snippets/social-meta-tags.liquid
@@ -2,9 +2,10 @@
 {%- assign og_url = canonical_url -%}
 {%- assign og_type = 'website' -%}
 {%- assign og_description = page_description | default: shop.description | default: shop.name -%}
+{%- assign og_image_default_size = '1200x1200' -%}
 {% if settings.share_image %}
-  {%- capture og_image_tags -%}<meta property="og:image" content="http:{{ settings.share_image | img_url: '1200x1200' }}">{%- endcapture -%}
-  {%- capture og_image_secure_url_tags -%}<meta property="og:image:secure_url" content="https:{{ settings.share_image | img_url: '1200x1200' }}">{%- endcapture -%}
+  {%- capture og_image_tags -%}<meta property="og:image" content="http:{{ settings.share_image | img_url: og_image_default_size }}">{%- endcapture -%}
+  {%- capture og_image_secure_url_tags -%}<meta property="og:image:secure_url" content="https:{{ settings.share_image | img_url: og_image_default_size }}">{%- endcapture -%}
 {% endif %}
 
 {% comment %}
@@ -15,12 +16,12 @@
   {%- assign og_type = 'product' -%}
   {%- capture og_image_tags -%}
     {%- for image in product.images limit: 3 -%}
-      <meta property="og:image" content="http:{{ image.src | product_img_url: '1024x1024' }}">
+      <meta property="og:image" content="http:{{ image.src | product_img_url: og_image_default_size }}">
     {%- endfor -%}
   {%- endcapture -%}
   {%- capture og_image_secure_url_tags -%}
     {%- for image in product.images limit: 3 -%}
-      <meta property="og:image:secure_url" content="https:{{ image.src | product_img_url: '1024x1024' }}">
+      <meta property="og:image:secure_url" content="https:{{ image.src | product_img_url: og_image_default_size }}">
     {%- endfor -%}
   {%- endcapture -%}
 
@@ -29,8 +30,8 @@
   {%- assign og_type = 'article' -%}
   {%- assign og_description = article.excerpt_or_content | strip_html -%}
   {%- if article.image -%}
-    {%- capture og_image_tags -%}<meta property="og:image" content="http:{{ article.image | img_url: '1024x1024' }}">{%- endcapture -%}
-    {%- capture og_image_secure_url_tags -%}<meta property="og:image:secure_url" content="https:{{ article.image | img_url: '1024x1024' }}">{%- endcapture -%}
+    {%- capture og_image_tags -%}<meta property="og:image" content="http:{{ article.image | img_url: og_image_default_size }}">{%- endcapture -%}
+    {%- capture og_image_secure_url_tags -%}<meta property="og:image:secure_url" content="https:{{ article.image | img_url: og_image_default_size }}">{%- endcapture -%}
   {%- endif -%}
 
 {%- elsif template.name == 'password' -%}

--- a/src/snippets/social-meta-tags.liquid
+++ b/src/snippets/social-meta-tags.liquid
@@ -2,26 +2,12 @@
 {%- assign og_url = canonical_url -%}
 {%- assign og_type = 'website' -%}
 {%- assign og_description = page_description | default: shop.description | default: shop.name -%}
-{%- assign og_image_default_size = '1200x1200' -%}
-{%- assign og_image_at_most_size = 1200 -%}
 {% if settings.share_image %}
-  {%- assign og_image = settings.share_image -%}
-  {%- assign og_image_ratio = og_image.aspect_ratio -%}
-  {%- if og_image_ratio > 1 -%}
-    {%- assign og_image_width = og_image.width | at_most: og_image_at_most_size -%}
-    {%- assign og_image_height = og_image_width | divided_by: og_image_ratio | round -%}
-  {%- elsif og_image_ratio < 1 -%}
-    {%- assign og_image_height = og_image.height | at_most: og_image_at_most_size -%}
-    {%- assign og_image_width = og_image_height | times: og_image_ratio | round -%}
-  {%- else -%}
-    {%- assign og_image_width = og_image.width | at_most: og_image_at_most_size -%}
-    {%- assign og_image_height = og_image.height | at_most: og_image_at_most_size -%}
-  {%- endif -%}
   {%- capture og_image_tags -%}
-    <meta property="og:image" content="http:{{ og_image | img_url: og_image_default_size }}">
-    <meta property="og:image:secure_url" content="https:{{ og_image | img_url: og_image_default_size }}">
-    <meta property="og:image:width" content="{{ og_image_width }}">
-    <meta property="og:image:height" content="{{ og_image_height }}">
+    <meta property="og:image" content="http:{{ settings.share_image | img_url: 'master' }}">
+    <meta property="og:image:secure_url" content="https:{{ settings.share_image | img_url: 'master' }}">
+    <meta property="og:image:width" content="{{ settings.share_image.width }}">
+    <meta property="og:image:height" content="{{ settings.share_image.height }}">
   {%- endcapture -%}
 {% endif %}
 
@@ -33,22 +19,10 @@
   {%- assign og_type = 'product' -%}
   {%- capture og_image_tags -%}
     {%- for image in product.images limit: 3 -%}
-      {%- assign og_image = image -%}
-      {%- assign og_image_ratio = og_image.aspect_ratio -%}
-      {%- if og_image_ratio > 1 -%}
-        {%- assign og_image_width = og_image.width | at_most: og_image_at_most_size -%}
-        {%- assign og_image_height = og_image_width | divided_by: og_image_ratio | round -%}
-      {%- elsif og_image_ratio < 1 -%}
-        {%- assign og_image_height = og_image.height | at_most: og_image_at_most_size -%}
-        {%- assign og_image_width = og_image_height | times: og_image_ratio | round -%}
-      {%- else -%}
-        {%- assign og_image_width = og_image.width | at_most: og_image_at_most_size -%}
-        {%- assign og_image_height = og_image.height | at_most: og_image_at_most_size -%}
-      {%- endif -%}
-      <meta property="og:image" content="http:{{ og_image | product_img_url: og_image_default_size }}">
-      <meta property="og:image:secure_url" content="https:{{ og_image | product_img_url: og_image_default_size }}">
-      <meta property="og:image:width" content="{{ og_image_width }}">
-      <meta property="og:image:height" content="{{ og_image_height }}">
+      <meta property="og:image" content="http:{{ image | product_img_url: 'master' }}">
+      <meta property="og:image:secure_url" content="https:{{ image | product_img_url: 'master' }}">
+      <meta property="og:image:width" content="{{ image.width }}">
+      <meta property="og:image:height" content="{{ image.height }}">
     {%- endfor -%}
   {%- endcapture -%}
 
@@ -57,23 +31,11 @@
   {%- assign og_type = 'article' -%}
   {%- assign og_description = article.excerpt_or_content | strip_html -%}
   {%- if article.image -%}
-    {%- assign og_image = article.image -%}
-    {%- assign og_image_ratio = og_image.aspect_ratio -%}
-    {%- if og_image_ratio > 1 -%}
-      {%- assign og_image_width = og_image.width | at_most: og_image_at_most_size -%}
-      {%- assign og_image_height = og_image_width | divided_by: og_image_ratio | round -%}
-    {%- elsif og_image_ratio < 1 -%}
-      {%- assign og_image_height = og_image.height | at_most: og_image_at_most_size -%}
-      {%- assign og_image_width = og_image_height | times: og_image_ratio | round -%}
-    {%- else -%}
-      {%- assign og_image_width = og_image.width | at_most: og_image_at_most_size -%}
-      {%- assign og_image_height = og_image.height | at_most: og_image_at_most_size -%}
-    {%- endif -%}
     {%- capture og_image_tags -%}
-      <meta property="og:image" content="http:{{ og_image | img_url: og_image_default_size }}">
-      <meta property="og:image:secure_url" content="https:{{ og_image | img_url: og_image_default_size }}">
-      <meta property="og:image:width" content="{{ og_image_width }}">
-      <meta property="og:image:height" content="{{ og_image_height }}">
+      <meta property="og:image" content="http:{{ article.image | img_url: 'master' }}">
+      <meta property="og:image:secure_url" content="https:{{ article.image | img_url: 'master' }}">
+      <meta property="og:image:width" content="{{ article.image.width }}">
+      <meta property="og:image:height" content="{{ article.image.height }}">
     {%- endcapture -%}
   {%- endif -%}
 

--- a/src/snippets/social-meta-tags.liquid
+++ b/src/snippets/social-meta-tags.liquid
@@ -4,8 +4,8 @@
 {%- assign og_description = page_description | default: shop.description | default: shop.name -%}
 {% if settings.share_image %}
   {%- capture og_image_tags -%}
-    <meta property="og:image" content="http:{{ settings.share_image | img_url: 'master' }}">
-    <meta property="og:image:secure_url" content="https:{{ settings.share_image | img_url: 'master' }}">
+    <meta property="og:image" content="http:{{ settings.share_image | img_url: 'master', format: 'jpg' }}">
+    <meta property="og:image:secure_url" content="https:{{ settings.share_image | img_url: 'master', format: 'jpg' }}">
     <meta property="og:image:width" content="{{ settings.share_image.width }}">
     <meta property="og:image:height" content="{{ settings.share_image.height }}">
     <meta property="og:image:alt" content="{{ settings.share_image.alt | escape }}">
@@ -20,8 +20,8 @@
   {%- assign og_type = 'product' -%}
   {%- capture og_image_tags -%}
     {%- for image in product.images limit: 3 -%}
-      <meta property="og:image" content="http:{{ image | product_img_url: 'master' }}">
-      <meta property="og:image:secure_url" content="https:{{ image | product_img_url: 'master' }}">
+      <meta property="og:image" content="http:{{ image | product_img_url: 'master', format: 'jpg' }}">
+      <meta property="og:image:secure_url" content="https:{{ image | product_img_url: 'master', format: 'jpg' }}">
       <meta property="og:image:width" content="{{ image.width }}">
       <meta property="og:image:height" content="{{ image.height }}">
       <meta property="og:image:alt" content="{{ image.alt | escape }}">
@@ -34,8 +34,8 @@
   {%- assign og_description = article.excerpt_or_content | strip_html -%}
   {%- if article.image -%}
     {%- capture og_image_tags -%}
-      <meta property="og:image" content="http:{{ article.image | img_url: 'master' }}">
-      <meta property="og:image:secure_url" content="https:{{ article.image | img_url: 'master' }}">
+      <meta property="og:image" content="http:{{ article.image | img_url: 'master', format: 'jpg' }}">
+      <meta property="og:image:secure_url" content="https:{{ article.image | img_url: 'master', format: 'jpg' }}">
       <meta property="og:image:width" content="{{ article.image.width }}">
       <meta property="og:image:height" content="{{ article.image.height }}">
       <meta property="og:image:alt" content="{{ article.image.alt | escape }}">

--- a/src/snippets/social-meta-tags.liquid
+++ b/src/snippets/social-meta-tags.liquid
@@ -89,6 +89,12 @@
 <meta property="og:type" content="{{ og_type }}">
 <meta property="og:description" content="{{ og_description }}">
 {%- if template.name == 'product' -%}
+  {%- if product.available -%}
+    {%- assign og_product_availability = 'instock' -%}
+  {%- else -%}
+    {%- assign og_product_availability = 'oos' -%}
+  {%- endif -%}
+  <meta property="product:availability" content="{{ og_product_availability }}">
   <meta property="product:price:amount" content="{{ product.price | money_without_currency | strip_html }}">
   <meta property="product:price:currency" content="{{ shop.currency }}">
 {%- endif -%}

--- a/src/snippets/social-meta-tags.liquid
+++ b/src/snippets/social-meta-tags.liquid
@@ -4,8 +4,8 @@
 {%- assign og_description = page_description | default: shop.description | default: shop.name -%}
 {% if settings.share_image %}
   {%- capture og_image_tags -%}
-    <meta property="og:image" content="http:{{ settings.share_image | img_url: 'master', format: 'jpg' }}">
-    <meta property="og:image:secure_url" content="https:{{ settings.share_image | img_url: 'master', format: 'jpg' }}">
+    <meta property="og:image" content="http:{{ settings.share_image | img_url: 'master' }}">
+    <meta property="og:image:secure_url" content="https:{{ settings.share_image | img_url: 'master' }}">
     <meta property="og:image:width" content="{{ settings.share_image.width }}">
     <meta property="og:image:height" content="{{ settings.share_image.height }}">
     <meta property="og:image:alt" content="{{ settings.share_image.alt | escape }}">
@@ -20,8 +20,8 @@
   {%- assign og_type = 'product' -%}
   {%- capture og_image_tags -%}
     {%- for image in product.images limit: 3 -%}
-      <meta property="og:image" content="http:{{ image | product_img_url: 'master', format: 'jpg' }}">
-      <meta property="og:image:secure_url" content="https:{{ image | product_img_url: 'master', format: 'jpg' }}">
+      <meta property="og:image" content="http:{{ image | product_img_url: 'master' }}">
+      <meta property="og:image:secure_url" content="https:{{ image | product_img_url: 'master' }}">
       <meta property="og:image:width" content="{{ image.width }}">
       <meta property="og:image:height" content="{{ image.height }}">
       <meta property="og:image:alt" content="{{ image.alt | escape }}">
@@ -34,8 +34,8 @@
   {%- assign og_description = article.excerpt_or_content | strip_html -%}
   {%- if article.image -%}
     {%- capture og_image_tags -%}
-      <meta property="og:image" content="http:{{ article.image | img_url: 'master', format: 'jpg' }}">
-      <meta property="og:image:secure_url" content="https:{{ article.image | img_url: 'master', format: 'jpg' }}">
+      <meta property="og:image" content="http:{{ article.image | img_url: 'master' }}">
+      <meta property="og:image:secure_url" content="https:{{ article.image | img_url: 'master' }}">
       <meta property="og:image:width" content="{{ article.image.width }}">
       <meta property="og:image:height" content="{{ article.image.height }}">
       <meta property="og:image:alt" content="{{ article.image.alt | escape }}">
@@ -47,8 +47,8 @@
   {%- assign og_type = 'product.group' -%}
   {%- if collection.image -%}
     {%- capture og_image_tags -%}
-      <meta property="og:image" content="http:{{ collection.image | img_url: 'master', format: 'jpg' }}">
-      <meta property="og:image:secure_url" content="https:{{ collection.image | img_url: 'master', format: 'jpg' }}">
+      <meta property="og:image" content="http:{{ collection.image | img_url: 'master' }}">
+      <meta property="og:image:secure_url" content="https:{{ collection.image | img_url: 'master' }}">
       <meta property="og:image:width" content="{{ collection.image.width }}">
       <meta property="og:image:height" content="{{ collection.image.height }}">
       <meta property="og:image:alt" content="{{ collection.image.alt | escape }}">

--- a/src/snippets/social-meta-tags.liquid
+++ b/src/snippets/social-meta-tags.liquid
@@ -33,8 +33,22 @@
   {%- assign og_type = 'product' -%}
   {%- capture og_image_tags -%}
     {%- for image in product.images limit: 3 -%}
-      <meta property="og:image" content="http:{{ image.src | product_img_url: og_image_default_size }}">
-      <meta property="og:image:secure_url" content="https:{{ image.src | product_img_url: og_image_default_size }}">
+      {%- assign og_image = image -%}
+      {%- assign og_image_ratio = og_image.aspect_ratio -%}
+      {%- if og_image_ratio > 1 -%}
+        {%- assign og_image_width = og_image.width | at_most: og_image_at_most_size -%}
+        {%- assign og_image_height = og_image_width | divided_by: og_image_ratio | round -%}
+      {%- elsif og_image_ratio < 1 -%}
+        {%- assign og_image_height = og_image.height | at_most: og_image_at_most_size -%}
+        {%- assign og_image_width = og_image_height | times: og_image_ratio | round -%}
+      {%- else -%}
+        {%- assign og_image_width = og_image.width | at_most: og_image_at_most_size -%}
+        {%- assign og_image_height = og_image.height | at_most: og_image_at_most_size -%}
+      {%- endif -%}
+      <meta property="og:image" content="http:{{ og_image | product_img_url: og_image_default_size }}">
+      <meta property="og:image:secure_url" content="https:{{ og_image | product_img_url: og_image_default_size }}">
+      <meta property="og:image:width" content="{{ og_image_width }}">
+      <meta property="og:image:height" content="{{ og_image_height }}">
     {%- endfor -%}
   {%- endcapture -%}
 

--- a/src/snippets/social-meta-tags.liquid
+++ b/src/snippets/social-meta-tags.liquid
@@ -89,8 +89,8 @@
 <meta property="og:type" content="{{ og_type }}">
 <meta property="og:description" content="{{ og_description }}">
 {%- if template.name == 'product' -%}
-  <meta property="og:price:amount" content="{{ product.price | money_without_currency | strip_html }}">
-  <meta property="og:price:currency" content="{{ shop.currency }}">
+  <meta property="product:price:amount" content="{{ product.price | money_without_currency | strip_html }}">
+  <meta property="product:price:currency" content="{{ shop.currency }}">
 {%- endif -%}
 {{ og_image_tags }}
 

--- a/src/snippets/social-meta-tags.liquid
+++ b/src/snippets/social-meta-tags.liquid
@@ -3,10 +3,25 @@
 {%- assign og_type = 'website' -%}
 {%- assign og_description = page_description | default: shop.description | default: shop.name -%}
 {%- assign og_image_default_size = '1200x1200' -%}
+{%- assign og_image_at_most_size = 1200 -%}
 {% if settings.share_image %}
+  {%- assign og_image = settings.share_image -%}
+  {%- assign og_image_ratio = og_image.aspect_ratio -%}
+  {%- if og_image_ratio > 1 -%}
+    {%- assign og_image_width = og_image.width | at_most: og_image_at_most_size -%}
+    {%- assign og_image_height = og_image_width | divided_by: og_image_ratio | round -%}
+  {%- elsif og_image_ratio < 1 -%}
+    {%- assign og_image_height = og_image.height | at_most: og_image_at_most_size -%}
+    {%- assign og_image_width = og_image_height | times: og_image_ratio | round -%}
+  {%- else -%}
+    {%- assign og_image_width = og_image.width | at_most: og_image_at_most_size -%}
+    {%- assign og_image_height = og_image.height | at_most: og_image_at_most_size -%}
+  {%- endif -%}
   {%- capture og_image_tags -%}
-    <meta property="og:image" content="http:{{ settings.share_image | img_url: og_image_default_size }}">
-    <meta property="og:image:secure_url" content="https:{{ settings.share_image | img_url: og_image_default_size }}">
+    <meta property="og:image" content="http:{{ og_image | img_url: og_image_default_size }}">
+    <meta property="og:image:secure_url" content="https:{{ og_image | img_url: og_image_default_size }}">
+    <meta property="og:image:width" content="{{ og_image_width }}">
+    <meta property="og:image:height" content="{{ og_image_height }}">
   {%- endcapture -%}
 {% endif %}
 
@@ -28,9 +43,23 @@
   {%- assign og_type = 'article' -%}
   {%- assign og_description = article.excerpt_or_content | strip_html -%}
   {%- if article.image -%}
+    {%- assign og_image = article.image -%}
+    {%- assign og_image_ratio = og_image.aspect_ratio -%}
+    {%- if og_image_ratio > 1 -%}
+      {%- assign og_image_width = og_image.width | at_most: og_image_at_most_size -%}
+      {%- assign og_image_height = og_image_width | divided_by: og_image_ratio | round -%}
+    {%- elsif og_image_ratio < 1 -%}
+      {%- assign og_image_height = og_image.height | at_most: og_image_at_most_size -%}
+      {%- assign og_image_width = og_image_height | times: og_image_ratio | round -%}
+    {%- else -%}
+      {%- assign og_image_width = og_image.width | at_most: og_image_at_most_size -%}
+      {%- assign og_image_height = og_image.height | at_most: og_image_at_most_size -%}
+    {%- endif -%}
     {%- capture og_image_tags -%}
-      <meta property="og:image" content="http:{{ article.image | img_url: og_image_default_size }}">
-      <meta property="og:image:secure_url" content="https:{{ article.image | img_url: og_image_default_size }}">
+      <meta property="og:image" content="http:{{ og_image | img_url: og_image_default_size }}">
+      <meta property="og:image:secure_url" content="https:{{ og_image | img_url: og_image_default_size }}">
+      <meta property="og:image:width" content="{{ og_image_width }}">
+      <meta property="og:image:height" content="{{ og_image_height }}">
     {%- endcapture -%}
   {%- endif -%}
 

--- a/src/snippets/social-meta-tags.liquid
+++ b/src/snippets/social-meta-tags.liquid
@@ -42,6 +42,19 @@
     {%- endcapture -%}
   {%- endif -%}
 
+{%- elsif template.name == 'collection' -%}
+  {%- assign og_title = collection.title | strip_html -%}
+  {%- assign og_type = 'product.group' -%}
+  {%- if collection.image -%}
+    {%- capture og_image_tags -%}
+      <meta property="og:image" content="http:{{ collection.image | img_url: 'master', format: 'jpg' }}">
+      <meta property="og:image:secure_url" content="https:{{ collection.image | img_url: 'master', format: 'jpg' }}">
+      <meta property="og:image:width" content="{{ collection.image.width }}">
+      <meta property="og:image:height" content="{{ collection.image.height }}">
+      <meta property="og:image:alt" content="{{ collection.image.alt | escape }}">
+    {%- endcapture -%}
+  {%- endif -%}
+
 {%- elsif template.name == 'password' -%}
   {%- assign og_title = shop.name -%}
   {%- assign og_url = shop.url -%}

--- a/src/snippets/social-meta-tags.liquid
+++ b/src/snippets/social-meta-tags.liquid
@@ -8,6 +8,7 @@
     <meta property="og:image:secure_url" content="https:{{ settings.share_image | img_url: 'master' }}">
     <meta property="og:image:width" content="{{ settings.share_image.width }}">
     <meta property="og:image:height" content="{{ settings.share_image.height }}">
+    <meta property="og:image:alt" content="{{ settings.share_image.alt | escape }}">
   {%- endcapture -%}
 {% endif %}
 
@@ -23,6 +24,7 @@
       <meta property="og:image:secure_url" content="https:{{ image | product_img_url: 'master' }}">
       <meta property="og:image:width" content="{{ image.width }}">
       <meta property="og:image:height" content="{{ image.height }}">
+      <meta property="og:image:alt" content="{{ image.alt | escape }}">
     {%- endfor -%}
   {%- endcapture -%}
 
@@ -36,6 +38,7 @@
       <meta property="og:image:secure_url" content="https:{{ article.image | img_url: 'master' }}">
       <meta property="og:image:width" content="{{ article.image.width }}">
       <meta property="og:image:height" content="{{ article.image.height }}">
+      <meta property="og:image:alt" content="{{ article.image.alt | escape }}">
     {%- endcapture -%}
   {%- endif -%}
 

--- a/src/snippets/social-meta-tags.liquid
+++ b/src/snippets/social-meta-tags.liquid
@@ -4,8 +4,10 @@
 {%- assign og_description = page_description | default: shop.description | default: shop.name -%}
 {%- assign og_image_default_size = '1200x1200' -%}
 {% if settings.share_image %}
-  {%- capture og_image_tags -%}<meta property="og:image" content="http:{{ settings.share_image | img_url: og_image_default_size }}">{%- endcapture -%}
-  {%- capture og_image_secure_url_tags -%}<meta property="og:image:secure_url" content="https:{{ settings.share_image | img_url: og_image_default_size }}">{%- endcapture -%}
+  {%- capture og_image_tags -%}
+    <meta property="og:image" content="http:{{ settings.share_image | img_url: og_image_default_size }}">
+    <meta property="og:image:secure_url" content="https:{{ settings.share_image | img_url: og_image_default_size }}">
+  {%- endcapture -%}
 {% endif %}
 
 {% comment %}
@@ -17,10 +19,6 @@
   {%- capture og_image_tags -%}
     {%- for image in product.images limit: 3 -%}
       <meta property="og:image" content="http:{{ image.src | product_img_url: og_image_default_size }}">
-    {%- endfor -%}
-  {%- endcapture -%}
-  {%- capture og_image_secure_url_tags -%}
-    {%- for image in product.images limit: 3 -%}
       <meta property="og:image:secure_url" content="https:{{ image.src | product_img_url: og_image_default_size }}">
     {%- endfor -%}
   {%- endcapture -%}
@@ -30,8 +28,10 @@
   {%- assign og_type = 'article' -%}
   {%- assign og_description = article.excerpt_or_content | strip_html -%}
   {%- if article.image -%}
-    {%- capture og_image_tags -%}<meta property="og:image" content="http:{{ article.image | img_url: og_image_default_size }}">{%- endcapture -%}
-    {%- capture og_image_secure_url_tags -%}<meta property="og:image:secure_url" content="https:{{ article.image | img_url: og_image_default_size }}">{%- endcapture -%}
+    {%- capture og_image_tags -%}
+      <meta property="og:image" content="http:{{ article.image | img_url: og_image_default_size }}">
+      <meta property="og:image:secure_url" content="https:{{ article.image | img_url: og_image_default_size }}">
+    {%- endcapture -%}
   {%- endif -%}
 
 {%- elsif template.name == 'password' -%}
@@ -50,7 +50,6 @@
   <meta property="og:price:currency" content="{{ shop.currency }}">
 {%- endif -%}
 {{ og_image_tags }}
-{{ og_image_secure_url_tags }}
 
 <meta name="twitter:site" content="{{ settings.social_twitter_link | split: 'twitter.com/' | last | prepend: '@' }}">
 <meta name="twitter:card" content="summary_large_image">


### PR DESCRIPTION
In order for Open Graph images to be instantly sharable, Facebook requires image height and width.  Otherwise Facebook first has to manually cache the page, and then the share image will be visible the second time someone shares the image.

> Use og:image:width and og:image:height Open Graph tags
> Using these tags will specify the image dimensions to the crawler so that it can render the image immediately without having to asynchronously download and process it.  

https://developers.facebook.com/docs/sharing/best-practices/#precaching

- Sets a new common, default share size `1200x1200`
- Sets an at most size of 1200 to limit the width to 1200px on landscape images and height to 1200px on portrait images
- Switch to a single image tag capture to allow for Open Graph "arrays" of images. Currently grouping all the `og:image` tags then followed by all the `og:image:secure_url` tags throws off the array of images. This especially becomes a problem when introducing the height and width values.
- Use the image ratio to calculate actual image height and widths at `1200x1200`

***

Fix Open Graph error with product price and product currency.  After setting `og:type` to `product` the correct property for price is `product:price:amount` and currency is `product:price:currency`
https://developers.facebook.com/docs/reference/opengraph/object-type/product/

![image](https://user-images.githubusercontent.com/454095/40810965-4ac85a28-64e4-11e8-9315-4dc284dfc5f7.png)
