### PR TITLE
Moved fill property to path selector for icon class

### DIFF
--- a/src/assets/styles/components/icons.scss
+++ b/src/assets/styles/components/icons.scss
@@ -3,7 +3,10 @@
   vertical-align: middle;
   width: 20px;
   height: 20px;
-  fill: currentColor;
+  
+  path {
+    fill: currentColor;
+  }
 
   .no-svg & {
     display: none;


### PR DESCRIPTION
Currently the fill property on the .icon class does not override the "path" color on svg icons. Moving this property to the path selector means colors set in CSS will be set for SVG icons.