### PR TITLE
Limit data-widths to only valid image widths

### DIFF
--- a/src/snippets/responsive-image.liquid
+++ b/src/snippets/responsive-image.liquid
@@ -57,12 +57,24 @@
 
 {%- assign img_url = image | img_url: '1x1' | replace: '_1x1.', '_{width}x.' -%}
 
+{%- comment -%} Limit image widths to valid options based on image.width {%- endcomment -%}
+{%- assign image_widths = '180,360,540,720,900,1080,1296,1512,1728,1944,2160,2376,2592,2808,3024' | split: ',' -%}
+{%- capture image_widths -%}
+  {%- for width in image_widths -%}
+    {%- comment -%} Check if image width is less or equal to width {%- endcomment -%}
+    {%- assign width_num = width | plus: 0 | round -%}
+    {%- if image.width >= width_num -%}{{ width_num }},{%- endif -%}
+  {%- endfor -%}
+  {{ image.width }}
+{%- endcapture -%}
+{%- assign image_widths = image_widths | strip_newlines -%}
+
 <div id="ImageWrapper-{{ image.id }}-{{ responsive_image_counter }}" data-image-id="{{ image.id }}" class="responsive-image__wrapper {{ wrapper_class }}" {{ wrapper_attributes }}>
   <img id="Image-{{ image.id }}-{{ responsive_image_counter }}"
     class="responsive-image__image lazyload {{ image_class }}"
     src="{{ image | img_url: '300x' }}"
     data-src="{{ img_url }}"
-    data-widths="[180, 360, 540, 720, 900, 1080, 1296, 1512, 1728, 1944, 2160, 2376, 2592, 2808, 3024]"
+    data-widths="[{{ image_widths }}]"
     data-aspectratio="{{ image.aspect_ratio }}"
     data-sizes="auto"
     tabindex="-1"


### PR DESCRIPTION
Currently images with a smaller `image.width` will output a lot of excess `srcset` values.  Shopify will fallback to the largest possible image in the case of a URL requesting a size larger than the image, however during a browser resize this will create additional unnecessary image downloads and browser repaints.

This change loops through the default list of widths and only returns valid widths based on the `image.width`.  Additionally, the `image.width` is prepended to the end of the `data-widths`.

#### Examples

- 1000px wide image - `data-widths="[180,360,540,720,900,1000]"`
- 2000px wide image - `data-widths="[180,360,540,720,900,1080,1296,1512,1728,1944,2000]"`
- 300px wide image - `data-widths="[180,300]"`
