### PR TITLE
Fix unique id for search forms

### DIFF
--- a/src/sections/header.liquid
+++ b/src/sections/header.liquid
@@ -79,13 +79,13 @@
     {% endif %}
 
     <form action="/search" method="get" role="search">
-      <label for="Search" class="label-hidden">
+      <label for="Search-{{ section.id }}" class="label-hidden">
         {{ 'general.search.placeholder' | t }}
       </label>
 
       <input type="search"
         name="q"
-        id="Search"
+        id="Search-{{ section.id }}"
         value="{{ search.terms | escape }}"
         placeholder="{{ 'general.search.placeholder' | t }}">
 


### PR DESCRIPTION
Quick fix for #57.

Kept same pattern with `Section-{{ section.id }}` like in [featured product](https://github.com/Shopify/starter-theme/blob/master/src/sections/featured-product.liquid#L85).