### PR TITLE
Add shopify_common.js condition

### DIFF
--- a/src/layout/theme.liquid
+++ b/src/layout/theme.liquid
@@ -48,6 +48,11 @@
     };
   </script>
 
+  {% if template.directory == 'customers' %}
+    <!--[if (gt IE 9)|!(IE)]><!--><script src="{{ 'shopify_common.js' | shopify_asset_url }}" defer="defer"></script><!--<![endif]-->
+    <!--[if lte IE 9]><script src="{{ 'shopify_common.js' | shopify_asset_url }}"></script><![endif]-->
+  {% endif %}
+
   {% include 'script-tags', layout: 'theme' %}
 
   {{ content_for_header }}

--- a/src/layout/theme.liquid
+++ b/src/layout/theme.liquid
@@ -49,8 +49,7 @@
   </script>
 
   {% if template.directory == 'customers' %}
-    <!--[if (gt IE 9)|!(IE)]><!--><script src="{{ 'shopify_common.js' | shopify_asset_url }}" defer="defer"></script><!--<![endif]-->
-    <!--[if lte IE 9]><script src="{{ 'shopify_common.js' | shopify_asset_url }}"></script><![endif]-->
+    <script src="{{ 'shopify_common.js' | shopify_asset_url }}" defer="defer"></script>
   {% endif %}
 
   {% include 'script-tags', layout: 'theme' %}


### PR DESCRIPTION
Fix #74.

Adds a condition to load `shopify_common.js` when needed. Other solutions might be addressed in the future, but let's fix the bug for now and revisit.