### PR TITLE
Remove slate-tools build from deploy script as yarn doesn't support a…

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "start": "slate-tools start",
     "watch": "slate-tools start --skipFirstDeploy",
     "build": "slate-tools build",
-    "deploy": "slate-tools build && slate-tools deploy",
+    "deploy": "slate-tools deploy",
     "zip": "slate-tools build && slate-tools zip",
     "lint": "slate-tools lint",
     "format": "slate-tools format"


### PR DESCRIPTION
…rguments in multiple scripts. Slate tools should manage the pre-build task on deploy instead.

