### PR TITLE
Fix usage of deprecated filters and values in social meta tags

### DIFF
--- a/src/snippets/social-meta-tags.liquid
+++ b/src/snippets/social-meta-tags.liquid
@@ -20,8 +20,8 @@
   {%- assign og_type = 'product' -%}
   {%- capture og_image_tags -%}
     {%- for image in product.images limit: 3 -%}
-      <meta property="og:image" content="http:{{ image | product_img_url: 'master' }}">
-      <meta property="og:image:secure_url" content="https:{{ image | product_img_url: 'master' }}">
+      <meta property="og:image" content="http:{{ image | img_url: 'master' }}">
+      <meta property="og:image:secure_url" content="https:{{ image | img_url: 'master' }}">
       <meta property="og:image:width" content="{{ image.width }}">
       <meta property="og:image:height" content="{{ image.height }}">
       <meta property="og:image:alt" content="{{ image.alt | escape }}">

--- a/src/snippets/social-meta-tags.liquid
+++ b/src/snippets/social-meta-tags.liquid
@@ -20,8 +20,8 @@
   {%- assign og_type = 'product' -%}
   {%- capture og_image_tags -%}
     {%- for image in product.images limit: 3 -%}
-      <meta property="og:image" content="http:{{ image | img_url: 'master' }}">
-      <meta property="og:image:secure_url" content="https:{{ image | img_url: 'master' }}">
+      <meta property="og:image" content="http:{{ image | img_url: '1024x' }}">
+      <meta property="og:image:secure_url" content="https:{{ image | img_url: '1024x' }}">
       <meta property="og:image:width" content="{{ image.width }}">
       <meta property="og:image:height" content="{{ image.height }}">
       <meta property="og:image:alt" content="{{ image.alt | escape }}">
@@ -34,8 +34,8 @@
   {%- assign og_description = article.excerpt_or_content | strip_html -%}
   {%- if article.image -%}
     {%- capture og_image_tags -%}
-      <meta property="og:image" content="http:{{ article.image | img_url: 'master' }}">
-      <meta property="og:image:secure_url" content="https:{{ article.image | img_url: 'master' }}">
+      <meta property="og:image" content="http:{{ article.image | img_url: '1024x' }}">
+      <meta property="og:image:secure_url" content="https:{{ article.image | img_url: '1024x' }}">
       <meta property="og:image:width" content="{{ article.image.width }}">
       <meta property="og:image:height" content="{{ article.image.height }}">
       <meta property="og:image:alt" content="{{ article.image.alt | escape }}">
@@ -47,8 +47,8 @@
   {%- assign og_type = 'product.group' -%}
   {%- if collection.image -%}
     {%- capture og_image_tags -%}
-      <meta property="og:image" content="http:{{ collection.image | img_url: 'master' }}">
-      <meta property="og:image:secure_url" content="https:{{ collection.image | img_url: 'master' }}">
+      <meta property="og:image" content="http:{{ collection.image | img_url: '1024x' }}">
+      <meta property="og:image:secure_url" content="https:{{ collection.image | img_url: '1024x' }}">
       <meta property="og:image:width" content="{{ collection.image.width }}">
       <meta property="og:image:height" content="{{ collection.image.height }}">
       <meta property="og:image:alt" content="{{ collection.image.alt | escape }}">


### PR DESCRIPTION
This pull request fixes some deprecated filters and values in the social meta tags snippet. I have used `1024x` for the new `img_url` image size, not 100% sure though the best value. Open to suggestions.

See deprecated filters:
[product_img_url](https://help.shopify.com/en/themes/liquid/filters/deprecated-filters#product_img_url)
[named size parameters](https://help.shopify.com/en/themes/liquid/filters/deprecated-filters#named-size-parameters)