### PR TITLE
Remove load on DOMContentLoaded

### DIFF
--- a/src/scripts/templates/index.js
+++ b/src/scripts/templates/index.js
@@ -1,6 +1,4 @@
 import {load} from '@shopify/theme-sections';
 import '../sections/product';
 
-document.addEventListener('DOMContentLoaded', () => {
-  load('*');
-});
+load('*');

--- a/src/scripts/templates/product.js
+++ b/src/scripts/templates/product.js
@@ -1,6 +1,4 @@
 import {load} from '@shopify/theme-sections';
 import '../sections/product';
 
-document.addEventListener('DOMContentLoaded', () => {
-  load('*');
-});
+load('*');


### PR DESCRIPTION
These files are included in bundles which are loaded using the `defer` attribute which means this script is always executed after DOMContentLoaded. These event handlers are not needed.