### PR TITLE
Product schema updates

### DIFF
--- a/src/sections/featured-product.liquid
+++ b/src/sections/featured-product.liquid
@@ -169,15 +169,20 @@
       "https:{{ product.featured_image.src | img_url: image_size }}"
     ],
   {% endif %}
-  "description": "{{ product.description | strip_html | escape }}",
+  {% if product.metafields.global.description_tag != blank %}
+    "description": "{{ product.metafields.global.description_tag }}",
+  {% else %}
+    "description": "{{ product.description | strip_html | strip_newlines | escape }}",
+  {% endif %}
   {% if current_variant.sku != blank %}
     "sku": "{{ current_variant.sku }}",
   {% endif %}
   "brand": {
     "@type": "Thing",
     "name": "{{ product.vendor | escape }}"
-  },
-  {% if product.variants %}
+  }
+  {% if product.variants.size > 1 %}
+    ,
     "offers": [
       {% for variant in product.variants %}
         {

--- a/src/templates/product.liquid
+++ b/src/templates/product.liquid
@@ -12,15 +12,20 @@
       "https:{{ product.featured_image.src | img_url: image_size }}"
     ],
   {% endif %}
-  "description": "{{ product.description | strip_html | escape }}",
+  {% if product.metafields.global.description_tag != blank %}
+    "description": "{{ product.metafields.global.description_tag }}",
+  {% else %}
+    "description": "{{ product.description | strip_html | strip_newlines | escape }}",
+  {% endif %}
   {% if current_variant.sku != blank %}
     "sku": "{{ current_variant.sku }}",
   {% endif %}
   "brand": {
     "@type": "Thing",
     "name": "{{ product.vendor | escape }}"
-  },
-  {% if product.variants %}
+  }
+  {% if product.variants.size > 1 %}
+    ,
     "offers": [
       {% for variant in product.variants %}
         {


### PR DESCRIPTION
Couple things on the Product JSON schema:

  - if you have a product description built in HTML, `strip_html` can end up with line breaks (i.e. if you had structured lists with line breaks between the list items) and you get invalid JSON and a console error - so adding `strip_newlines` filter here
  - also, the product description is often not what you want in the schema, especially in the above case where the description is in html, you might end up with a nonsense description.  If you have set the SEO description on the product, that is a better candidate for the schema description.
  - `{% if product.variants %}` returns true for all products; it seems that each product starts with 1 variant by default.  If this did ever return false, you'd get invalid JSON again with the trailing comma left after `"brand": {}`.  Replacing this with `{% if product.variants.size > 1 %}`

I didn't want to go this far, but also wondering if you guys think the Product JSON schema  should be pulled out into its own snippet, as it's duplicated in the two files below.  Happy to update this PR to do that.

Thanks!