### PR TITLE
Update responsive-image.liquid

### DIFF
--- a/src/snippets/responsive-image.liquid
+++ b/src/snippets/responsive-image.liquid
@@ -67,7 +67,7 @@
   {%- endfor -%}
   {{- image.width -}}
 {%- endcapture -%}
-{%- assign image_widths = image_widths | strip_newlines -%}
+{%- assign image_widths = image_widths | strip -%}
 
 <div id="ImageWrapper-{{ image.id }}-{{ responsive_image_counter }}" data-image-id="{{ image.id }}" class="responsive-image__wrapper {{ wrapper_class }}" {{ wrapper_attributes }}>
   <img id="Image-{{ image.id }}-{{ responsive_image_counter }}"

--- a/src/snippets/responsive-image.liquid
+++ b/src/snippets/responsive-image.liquid
@@ -65,7 +65,7 @@
     {%- assign width_num = width | plus: 0 | round -%}
     {%- if image.width >= width_num -%}{{ width_num }},{%- endif -%}
   {%- endfor -%}
-  {{ image.width }}
+  {{- image.width -}}
 {%- endcapture -%}
 {%- assign image_widths = image_widths | strip_newlines -%}
 

--- a/src/snippets/responsive-image.liquid
+++ b/src/snippets/responsive-image.liquid
@@ -65,7 +65,7 @@
     {%- assign width_num = width | plus: 0 | round -%}
     {%- if image.width >= width_num -%}{{ width_num }},{%- endif -%}
   {%- endfor -%}
-  {{- image.width -}}
+  {{ image.width }}
 {%- endcapture -%}
 {%- assign image_widths = image_widths | strip -%}
 


### PR DESCRIPTION
Whitespace control for image.width inside image_widths caption block. At the moment it would create a new line causing lazysizes to fail.