### PR TITLE
Add strip_newlines filter to description in product.liquid

### DIFF
--- a/src/templates/product.liquid
+++ b/src/templates/product.liquid
@@ -12,7 +12,7 @@
       "https:{{ product.featured_image.src | img_url: image_size }}"
     ],
   {% endif %}
-  "description": "{{ product.description | strip_html | escape }}",
+  "description": "{{ product.description | strip_html | strip_newlines | escape }}",
   {% if current_variant.sku != blank %}
     "sku": "{{ current_variant.sku }}",
   {% endif %}


### PR DESCRIPTION
Adding the `strip_newlines` filter to descriptions to avoid descriptions that include line breaks from creating invalid json output.