### PR TITLE
Use correct variable for order subtotal

### DIFF
--- a/src/templates/customers/order.liquid
+++ b/src/templates/customers/order.liquid
@@ -66,7 +66,7 @@
   <tfoot>
     <tr class="responsive-table-row">
       <td colspan="4" class="small--hide">{{ 'customer.order.subtotal' | t }}</td>
-      <td data-label="{{ 'customer.order.subtotal' | t }}">{{ order.subtotal_price | money }}</td>
+      <td data-label="{{ 'customer.order.subtotal' | t }}">{{ order.line_items_subtotal_price | money }}</td>
     </tr>
 
     {% for discount in order.discounts %}


### PR DESCRIPTION
The order template was using the incorrect variable for displaying the subtotal before cart level discounts. It should be using https://help.shopify.com/en/themes/liquid/objects/order#order-subtotal_price