### PR TITLE
Escape article.liquid "articleBody" content

### DIFF
--- a/src/templates/article.liquid
+++ b/src/templates/article.liquid
@@ -173,7 +173,7 @@
 {
   "@context": "http://schema.org",
   "@type": "Article",
-  "articleBody": "{{ article.content | strip_html }}",
+  "articleBody": "{{ article.content | strip_html | escape }}",
   "mainEntityOfPage": {
     "@type": "WebPage",
     "@id": "{{ shop.url }}{{ page.url }}"


### PR DESCRIPTION
Googlebot throwing error below for blog articles with quote marks ("")

> Parsing error: Missing ',' or '}'

Added escape filter to the JSON-LD so these pages could be indexed
properly.