### PR TITLE
Update theme author, documentation and support values in settings schema

### DIFF
--- a/src/config/settings_schema.json
+++ b/src/config/settings_schema.json
@@ -3,9 +3,9 @@
     "name": "theme_info",
     "theme_name": "Starter theme",
     "theme_version": "1.0.0",
-    "theme_author": "Shopify",
-    "theme_documentation_url": "https://github.com/Shopify/starter-theme",
-    "theme_support_url": "https://github.com/Shopify/starter-theme/issues"
+    "theme_author": "THEME_AUTHOR",
+    "theme_documentation_url": "https:\/\/THEME_DOCUMENTATION_URL.com\/",
+    "theme_support_url": "https:\/\/THEME_SUPPORT_URL.com\/"
   },
   {
     "name": "Colors",


### PR DESCRIPTION
Many themes across Shopify are still leveraging the starter theme as a starting point to theme development.

We're noticing that there are many occurrences in which theme developers never update the values for `theme_author`, `theme_documentation_url`, and `theme_support_url` inside of the `config/settings_schema.json` file to their own. As a result, Shopify is getting hit with lots of support requests. This PR updates the list of values to be generic, encouraging theme developers to change them for their own themes.