### PR TITLE
update to use image_url

### DIFF
--- a/src/snippets/social-meta-tags.liquid
+++ b/src/snippets/social-meta-tags.liquid
@@ -20,8 +20,8 @@
   {%- assign og_type = 'product' -%}
   {%- capture og_image_tags -%}
     {%- for image in product.images limit: 3 -%}
-      <meta property="og:image" content="http:{{ image | product_img_url: 'master' }}">
-      <meta property="og:image:secure_url" content="https:{{ image | product_img_url: 'master' }}">
+      <meta property="og:image" content="http:{{ image | image_url: 'master' }}">
+      <meta property="og:image:secure_url" content="https:{{ image | image_url: 'master' }}">
       <meta property="og:image:width" content="{{ image.width }}">
       <meta property="og:image:height" content="{{ image.height }}">
       <meta property="og:image:alt" content="{{ image.alt | escape }}">


### PR DESCRIPTION
I noticed an issue with the starter theme where the og:image url being passed to facebook was returning

```
http:/cdn/shop/files/....
```

instead 

```
http://store-name.myshopify.com/cdn/shop/files/....
```

This is an attempt to fix this but i am unable to test out the code. 

Im also not 100% sure if the cdn url returns the domain back so this whole fix might be incorrect. 


Any help is appreciated 🙏 